### PR TITLE
Fix broken smoketest

### DIFF
--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -45,6 +45,8 @@ jobs:
       - name: Run tests
         env:
           COPILOT_TOKEN: ${{ secrets.COPILOT_TOKEN }}
+          GITHUB_AUTH_HEADER: "Bearer ${{ secrets.GITHUB_TOKEN }}"
+
         run: |
           source .venv/bin/activate
           python main.py -p GitHubSecurityLab/seclab-taskflow-agent/personalities/assistant 'explain modems to me please'


### PR DESCRIPTION
We forgot to add the `GITHUB_AUTH_HEADER` environment variable in the smoketest, which is needed by the `github-official` mcp server.