### PR TITLE
Fix broken docker release

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -32,6 +32,7 @@
 ./env_utils.py
 ./render_utils.py
 ./shell_utils.py
+./available_tools.py
 
 # prompts
 ./prompts/examples/example_prompt.yaml


### PR DESCRIPTION
Docker release is broken because we forgot to add `available_tools` to the container when we added the file.