### PR TITLE
Set verbose=true to investigate why upload is failing

### DIFF
--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -50,6 +50,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: https://test.pypi.org/legacy/
+        verbose: true
 
     - name: Sign with sigstore
       uses: sigstore/gh-action-sigstore-python@f832326173235dcb00dd5d92cd3f353de3188e6c # v3.1.0


### PR DESCRIPTION
I'm trying to figure out why the upload is failing: https://github.com/GitHubSecurityLab/seclab-taskflow-agent/actions/runs/19138665665/job/54697334348