### PR TITLE
Change to correct name

### DIFF
--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -10,7 +10,7 @@ jobs:
     # This environment is required as an input to pypa/gh-action-pypi-publish
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/seclab-taskflow-agent2
+      url: https://test.pypi.org/p/seclab-taskflow-agent
 
     env:
       GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
The reason why the upload to test.pypi.org isn't working is that we're trying to upload to a project name that doesn't match what we've got in `pyproject.toml`.