### PR TITLE
Search for .env in current directory

### DIFF
--- a/src/seclab_taskflow_agent/__main__.py
+++ b/src/seclab_taskflow_agent/__main__.py
@@ -6,7 +6,7 @@ from threading import Thread
 import argparse
 import os
 import sys
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 import logging
 from logging.handlers import RotatingFileHandler
 from pprint import pprint, pformat
@@ -34,7 +34,7 @@ from .agent import TaskAgent
 from .capi import list_tool_call_models
 from .available_tools import AvailableTools
 
-load_dotenv()
+load_dotenv(find_dotenv(usecwd=True))
 
 # only model output or help message should go to stdout, everything else goes to log
 logging.getLogger('').setLevel(logging.NOTSET)

--- a/src/seclab_taskflow_agent/agent.py
+++ b/src/seclab_taskflow_agent/agent.py
@@ -4,7 +4,7 @@
 # https://openai.github.io/openai-agents-python/agents/
 import os
 import logging
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
@@ -18,7 +18,7 @@ from agents import Agent, Runner, AgentHooks, RunHooks, result, function_tool, T
 from .capi import COPILOT_INTEGRATION_ID, COPILOT_API_ENDPOINT
 
 # grab our secrets from .env, this must be in .gitignore
-load_dotenv()
+load_dotenv(find_dotenv(usecwd=True))
 
 match urlparse(COPILOT_API_ENDPOINT).netloc:
     case 'api.githubcopilot.com':


### PR DESCRIPTION
Apparently `load_dotenv()` uses the location of the script by default, not the `cwd`.