### PR TITLE
Move TestPyPI to the end, so it can't stop the other steps from succeeding

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -45,12 +45,6 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        verbose: true
-
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
@@ -68,3 +62,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_NAME: ${{ github.ref_name }}
       run: gh release create $RELEASE_NAME dist/* --repo $GITHUB_REPO --generate-notes
+
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true
+        attestations: false


### PR DESCRIPTION
The workflow [failed](https://github.com/GitHubSecurityLab/seclab-taskflow-agent/actions/runs/19364149720/job/55402997879) with this error message:

```
Error: Attestation generation failure: The following distributions already have publish attestations: * /github/workspace/dist/seclab_taskflow_agent-0.0.4-py3-none-any.whl -> /github/workspace/dist/seclab_taskflow_agent-0.0.4-py3-none-any.whl.publish.attestation
```

The problem is that I'm trying to publish to both PyPI and TestPyPI, which is causing it to generate the same attestation twice, which isn't allowed. So this PR does two things:

* Move the TestPyPI step to the end so that it can't stop the other steps from succeeding
* Set `attestations: false` on the TestPyPI step.