### PR TITLE
Remove the TestPyPI step

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -62,10 +62,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_NAME: ${{ github.ref_name }}
       run: gh release create $RELEASE_NAME dist/* --repo $GITHUB_REPO --generate-notes
-
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        verbose: true
-        attestations: false


### PR DESCRIPTION
It turns out that it isn't possible to publish the same version number to both PyPI and TestPyPI, which is what I was trying to do here. So deleting this step from the workflow.