### PR TITLE
Add smoketest environment

### DIFF
--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   Linux:
     runs-on: ubuntu-latest
+    environment: smoketest
     if: github.event.issue.pull_request  # Make sure the comment is on a PR
     steps:
       - name: branch-deploy


### PR DESCRIPTION
The smoke test is currently getting listed as a deployment to "production", which looks confusing on the main page of the repo:

<img width="444" height="350" alt="Screenshot from 2025-11-24 15-03-10" src="https://github.com/user-attachments/assets/3f405fd0-8616-4224-9a84-f56a704513a6" />

I think adding an environment to the workflow should fix it.