### PR TITLE
Use "exit 1" to abort if branch-deploy fails

### DIFF
--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -29,7 +29,7 @@ jobs:
           stable_branch: "main"
           update_branch: "disabled"
 
-      - name: Check branch-deploy result
+      - name: Check Branch Deploy result
         env:
           BRANCH_DEPLOY_RESULT: ${{ steps.branch-deploy.outputs.continue }}
         run: |


### PR DESCRIPTION
Separating into two separate jobs (#107) doesn't work well, because any error messages from the second job don't get reported back as comments on the issue.

This is a cruder solution that will hopefully work better.