### PR TITLE
Rename GITHUB_PERSONAL_ACCESS_TOKEN to GH_TOKEN

### DIFF
--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -7,8 +7,8 @@ if [ -v CODESPACES ]; then
     if [ ! -v AI_API_TOKEN ]; then
         echo "⚠️ Running in Codespaces - please add AI_API_TOKEN to your Codespaces secrets"
     fi
-    if [ ! -v GITHUB_PERSONAL_ACCESS_TOKEN ]; then
-        echo "⚠️ Running in Codespaces - please add GITHUB_PERSONAL_ACCESS_TOKEN to your Codespaces secrets"
+    if [ ! -v GH_TOKEN ]; then
+        echo "⚠️ Running in Codespaces - please add GH_TOKEN to your Codespaces secrets"
     fi
 fi
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Example:
 # Tokens
 AI_API_TOKEN=<your_github_token>
 # MCP configs
-GITHUB_PERSONAL_ACCESS_TOKEN=<your_github_token>
+GH_TOKEN=<your_github_token>
 CODEQL_DBS_BASE_PATH="/app/my_data/codeql_databases"
 ```
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -19,6 +19,6 @@ touch -a .env
 
 docker run -i \
        --mount type=bind,src="$PWD",dst=/app \
-       -e GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN" \
+       -e GH_TOKEN="$GH_TOKEN" \
        -e AI_API_TOKEN="$AI_API_TOKEN" \
        "ghcr.io/githubsecuritylab/seclab-taskflow-agent" "$@"


### PR DESCRIPTION
Codespace secrets are not allowed to have a name that starts with "GITHUB".

I ran this command to replace the name everywhere:

```bash
find . -type f -exec sed -i 's/GITHUB_PERSONAL_ACCESS_TOKEN/GH_TOKEN/g' {} \;
```