### PR TITLE
revert render_stdout logging

### DIFF
--- a/src/seclab_taskflow_agent/render_utils.py
+++ b/src/seclab_taskflow_agent/render_utils.py
@@ -8,7 +8,11 @@ from .path_utils import log_file_name
 async_output = {}
 async_output_lock = asyncio.Lock()
 
-LOG_FILE = log_file_name('render_stdout.log')
+render_logger = logging.getLogger("render")
+file_handler = logging.FileHandler(log_file_name('render_stdout.log'))
+file_handler.terminator = ""
+render_logger.addHandler(file_handler)
+render_logger.propagate = False
 
 async def flush_async_output(task_id: str):
     async with async_output_lock:
@@ -35,6 +39,5 @@ async def render_model_output(data: str,
                 data = "** 🤖✏️ Gathering output from async task ... please hold\n"
     if data:
         if log:
-            with open(LOG_FILE, 'a') as f:
-                f.write(data)
+            render_logger.info(data)
         print(data, end="", flush=True)


### PR DESCRIPTION
Because `render_stdout` is meant to be a record of the console, not a log file and the change pollutes it with all the debug log from the process itself.