### PR TITLE
provide LOG_DIR env var to existing MCP servers

### DIFF
--- a/src/seclab_taskflow_agent/toolboxes/codeql.yaml
+++ b/src/seclab_taskflow_agent/toolboxes/codeql.yaml
@@ -17,6 +17,7 @@ server_params:
     GH_NO_UPDATE_NOTIFIER: "Disable"
     GH_NO_EXTENSION_UPDATE_NOTIFIER: "Disable"
     CODEQL_CLI: "{{ env CODEQL_CLI }}"
+    LOG_DIR: "{{ env LOG_DIR }}"
 server_prompt: |
   ## CodeQL Supported Programming Languages
   

--- a/src/seclab_taskflow_agent/toolboxes/echo.yaml
+++ b/src/seclab_taskflow_agent/toolboxes/echo.yaml
@@ -12,3 +12,4 @@ server_params:
   args: ["-m", "seclab_taskflow_agent.mcp_servers.echo.echo"]
   env:
     TEST: value
+    LOG_DIR: "{{ env LOG_DIR }}"

--- a/src/seclab_taskflow_agent/toolboxes/logbook.yaml
+++ b/src/seclab_taskflow_agent/toolboxes/logbook.yaml
@@ -11,6 +11,7 @@ server_params:
   args: ["-m", "seclab_taskflow_agent.mcp_servers.logbook.logbook"]
   env:
     LOGBOOK_STATE_DIR: "{{ env LOGBOOK_STATE_DIR }}"
+    LOG_DIR: "{{ env LOG_DIR }}"
 # the list of tools that you want the framework to confirm with the user before executing
 # use this to guard rail any potentially dangerous functions from MCP servers
 confirm:

--- a/src/seclab_taskflow_agent/toolboxes/memcache.yaml
+++ b/src/seclab_taskflow_agent/toolboxes/memcache.yaml
@@ -12,6 +12,7 @@ server_params:
   env:
     MEMCACHE_STATE_DIR: "{{ env MEMCACHE_STATE_DIR }}"
     MEMCACHE_BACKEND: "{{ env MEMCACHE_BACKEND }}"
+    LOG_DIR: "{{ env LOG_DIR }}"
 # the list of tools that you want the framework to confirm with the user before executing
 # use this to guard rail any potentially dangerous functions from MCP servers
 confirm:


### PR DESCRIPTION
this way the MCP servers will log into the "globally" defined LOG_DIR