### PR TITLE
Replace GITHUB_AUTH_HEADER with GH_TOKEN

### DIFF
--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -54,7 +54,7 @@ jobs:
           MODEL_TEMP: ${{ vars.SMOKETEST_TEMPERATURE }}
           AI_API_ENDPOINT: ${{ vars.SMOKETEST_ENDPOINT }}
           AI_API_TOKEN: ${{ secrets.AI_API_TOKEN }}
-          GITHUB_AUTH_HEADER: "Bearer ${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         run: |
           source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ server_params:
   url: https://api.githubcopilot.com/mcp/
   #See https://github.com/github/github-mcp-server/blob/main/docs/remote-server.md
   headers:
-    Authorization: "{{ env('GITHUB_AUTH_HEADER') }}"
+    Authorization: "Bearer {{ env('GH_TOKEN') }}"
   optional_headers:
     X-MCP-Toolsets: "{{ env('GITHUB_MCP_TOOLSETS') }}"
     X-MCP-Readonly: "{{ env('GITHUB_MCP_READONLY') }}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -12,7 +12,7 @@
 #   git clone https://github.com/GitHubSecurityLab/seclab-taskflow-agent.git
 #   cd seclab-taskflow-agent/src
 #   export AI_API_TOKEN=<My GitHub PAT>
-#   export GITHUB_AUTH_HEADER=<My GitHub PAT>
+#   export GH_TOKEN=<My GitHub PAT>
 #   sudo -E ../docker/run.sh -p seclab_taskflow_agent.personalities.assistant 'explain modems to me please'
 
 touch -a .env

--- a/src/seclab_taskflow_agent/toolboxes/github_official.yaml
+++ b/src/seclab_taskflow_agent/toolboxes/github_official.yaml
@@ -10,7 +10,7 @@ server_params:
   url: https://api.githubcopilot.com/mcp/
   #See https://github.com/github/github-mcp-server/blob/main/docs/remote-server.md
   headers:
-    Authorization: "{{ env('GITHUB_AUTH_HEADER') }}"
+    Authorization: "Bearer {{ env('GH_TOKEN') }}"
   optional_headers:
     X-MCP-Toolsets: "{{ env('GITHUB_MCP_TOOLSETS') }}"
     X-MCP-Readonly: "{{ env('GITHUB_MCP_READONLY') }}"


### PR DESCRIPTION
I think these tokens will always be the same, so there's no reason to have two separate environment variables.