### PR TITLE
Add build provenance attestation

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: write
       id-token: write  # For trusted publishing
+      attestations: write  # For artifact attestation
 
     steps:
     - name: Checkout repository
@@ -39,23 +40,21 @@ jobs:
     - name: Build the wheel
       run: python3 -m hatch build
 
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+      with:
+        subject-path: ./dist/*
+
     - name: Upload artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
         name: python-package-distributions
-        path: dist/
+        path: ./dist/
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         verbose: true
-
-    - name: Sign with sigstore
-      uses: sigstore/gh-action-sigstore-python@f832326173235dcb00dd5d92cd3f353de3188e6c # v3.1.0
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
 
     - name: Create GitHub Release
       env:

--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
       id-token: write  # For trusted publishing
+      attestations: write  # For artifact attestation
 
     steps:
     - name: Checkout repository
@@ -51,24 +52,22 @@ jobs:
     - name: Build the wheel
       run: python3 -m hatch build
 
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+      with:
+        subject-path: ./dist/*
+
     - name: Upload artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
         name: python-package-distributions
-        path: dist/
+        path: ./dist/
 
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: https://test.pypi.org/legacy/
         verbose: true
-
-    - name: Sign with sigstore
-      uses: sigstore/gh-action-sigstore-python@f832326173235dcb00dd5d92cd3f353de3188e6c # v3.1.0
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
 
     - name: Create GitHub Release
       env:


### PR DESCRIPTION
I noticed that we have this in the `release.yml` workflow but not in these two workflows. I was a bit confused because we already have a "sign with sigstore" step in these workflows. As I understand it, "sign with sigstore" is the preferred way to sign the artifacts for PyPI and attest-build-provenance is the prefered way to do it for GitHub releases. And it doesn't hurt to do both.