### PR TITLE
docs: update tests/README.md to reference hatch

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,33 +1,47 @@
 # Python Tests
 
-based on pytest.
+Tests are managed via [Hatch](https://hatch.pypa.io/) and run with pytest.
 
 ## Running Tests
-
-Make sure to install test dependencies: `pip install -r requirements-test.txt`.
 
 ### All Tests
 
 ```bash
-pytest
+hatch test
 ```
 
+### Target a specific Python version
+
+```bash
+hatch test --python 3.11
+hatch test --python 3.13
+```
 
 ### Specific Test File
+
 ```bash
-pytest tests/test_yaml_parser.py -v
+hatch test -- tests/test_yaml_parser.py -v
 ```
 
 ### Specific Test Class
+
 ```bash
-pytest tests/test_yaml_parser.py::TestYamlParser -v
+hatch test -- tests/test_yaml_parser.py::TestYamlParser -v
 ```
 
 ### Specific Test Function
+
 ```bash
-pytest tests/test_yaml_parser.py::TestYamlParser::test_yaml_parser_basic_functionality -v
+hatch test -- tests/test_yaml_parser.py::TestYamlParser::test_yaml_parser_basic_functionality -v
+```
+
+### Full CI invocation
+
+```bash
+hatch fmt --linter --check
+hatch test --python 3.11 --cover --randomize --parallel --retries 2 --retry-delay 1
 ```
 
 ## Test Configuration
 
-See `pytest.ini` in the root directory.
+See `[tool.hatch]` and `[tool.coverage]` sections in `pyproject.toml`.


### PR DESCRIPTION
## Problem

`tests/README.md` references `pip install -r requirements-test.txt` and `pytest.ini`, neither of which exist. The project uses hatch for test orchestration (`hatch test`), so the instructions are broken for anyone trying to run tests from the README.

## Changes

Replaces all stale references with working hatch commands:
- `hatch test` for running all tests
- `hatch test --python 3.11` / `3.13` for targeting specific versions
- `hatch test -- tests/file.py -v` for running specific files/classes/functions
- Full CI invocation example: `hatch fmt --linter --check` + `hatch test --python 3.11 --cover --randomize --parallel --retries 2 --retry-delay 1`
- Points test configuration to `pyproject.toml` instead of nonexistent `pytest.ini`