### PR TITLE
feat: add auto-save scaffolding for periodic tool-result logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Failed tasks are automatically retried up to 3 times with increasing backoff
 before the session is saved. Session checkpoints are stored in the
 platform-specific application data directory.
 
+### Auto-save tool log
+
+Set `AUTO_SAVE_DIR` and `AUTO_SAVE_INTERVAL` to enable periodic tool-result
+logging. Every N tool calls, the runner appends an NDJSON entry to
+`{AUTO_SAVE_DIR}/auto_save_tool_log.ndjson`. Disabled by default (interval=0).
+
 ### Error Output
 
 By default, errors are shown as concise one-line messages. Use `--debug` (or

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -64,7 +64,7 @@ def write_auto_save(
     tool_name: str,
     result: str,
 ) -> None:
-    """Append tool result to auto-save log (NDJSON, append-only, crash-safe)."""
+    """Append tool result to auto-save log (NDJSON, append-only)."""
     try:
         os.makedirs(auto_save_dir, exist_ok=True)
         save_path = os.path.join(auto_save_dir, AUTO_SAVE_LOG_NAME)
@@ -73,7 +73,7 @@ def write_auto_save(
             "tool": tool_name,
             "result_preview": (result or "")[:2000],
         })
-        with open(save_path, "a") as f:
+        with open(save_path, "a", encoding="utf-8") as f:
             f.write(entry + "\n")
     except Exception as e:
         logging.warning(f"Auto-save failed: {e}")
@@ -87,7 +87,7 @@ def read_tool_log(auto_save_dir: str) -> list[dict]:
     try:
         path = os.path.join(auto_save_dir, AUTO_SAVE_LOG_NAME)
         if os.path.exists(path):
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if not line:
@@ -517,7 +517,11 @@ async def run_main(
     # Disabled by default (interval=0).  Set AUTO_SAVE_DIR and
     # AUTO_SAVE_INTERVAL to enable.
     _tool_call_counter = [0]
-    _auto_save_interval = int(os.getenv("AUTO_SAVE_INTERVAL", "0"))
+    try:
+        _auto_save_interval = int(os.getenv("AUTO_SAVE_INTERVAL", "0"))
+    except ValueError:
+        logging.warning("Invalid AUTO_SAVE_INTERVAL value, defaulting to 0 (disabled)")
+        _auto_save_interval = 0
     _auto_save_dir = os.getenv("AUTO_SAVE_DIR", "")
 
     async def on_tool_end_hook(context: RunContextWrapper[TContext], agent: Agent[TContext], tool: Tool, result: str) -> None:

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -20,6 +20,7 @@ __all__ = [
 ]
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -467,8 +468,52 @@ async def run_main(
 
     last_mcp_tool_results: list[str] = []
 
+    # Auto-save scaffolding: periodically persist tool results to disk.
+    # Disabled by default (interval=0).  Set AUTO_SAVE_DIR and
+    # AUTO_SAVE_INTERVAL to enable.
+    _tool_call_counter = [0]
+    _auto_save_interval = int(os.getenv("AUTO_SAVE_INTERVAL", "0"))
+    _auto_save_dir = os.getenv("AUTO_SAVE_DIR", "")
+
+    def _write_auto_save(tool_name: str, result: str) -> None:
+        """Append tool result to auto-save log (NDJSON, append-only, crash-safe)."""
+        try:
+            os.makedirs(_auto_save_dir, exist_ok=True)
+            save_path = os.path.join(_auto_save_dir, "auto_save_tool_log.ndjson")
+            entry = json.dumps({
+                "turn": _tool_call_counter[0],
+                "tool": tool_name,
+                "result_preview": (result or "")[:2000],
+            })
+            with open(save_path, "a") as f:
+                f.write(entry + "\n")
+        except Exception as e:
+            logging.warning(f"Auto-save failed: {e}")
+
+    def _read_tool_log() -> list[dict]:
+        """Read NDJSON auto-save log.  Skips malformed lines."""
+        if not _auto_save_dir:
+            return []
+        entries: list[dict] = []
+        try:
+            path = os.path.join(_auto_save_dir, "auto_save_tool_log.ndjson")
+            if os.path.exists(path):
+                with open(path) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        with contextlib.suppress(json.JSONDecodeError):
+                            entries.append(json.loads(line))
+        except Exception:
+            logging.debug("Failed to read auto-save tool log", exc_info=True)
+        return entries
+
     async def on_tool_end_hook(context: RunContextWrapper[TContext], agent: Agent[TContext], tool: Tool, result: str) -> None:
         last_mcp_tool_results.append(result)
+        _tool_call_counter[0] += 1
+        if _auto_save_dir and _auto_save_interval and _tool_call_counter[0] % _auto_save_interval == 0:
+            _write_auto_save(tool.name, result)
 
     async def on_tool_start_hook(context: RunContextWrapper[TContext], agent: Agent[TContext], tool: Tool) -> None:
         await render_model_output(f"\n** 🤖🛠️ Tool Call: {tool.name}\n")

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -16,7 +16,9 @@ __all__ = [
     "MAX_RATE_LIMIT_BACKOFF",
     "RATE_LIMIT_BACKOFF",
     "deploy_task_agents",
+    "read_tool_log",
     "run_main",
+    "write_auto_save",
 ]
 
 import asyncio
@@ -52,6 +54,49 @@ MAX_RATE_LIMIT_BACKOFF = 120  # Maximum backoff cap in seconds for rate-limit re
 MAX_API_RETRY = 5  # Maximum number of consecutive API error retries
 TASK_RETRY_LIMIT = 3  # Maximum retry attempts for a failed task
 TASK_RETRY_BACKOFF = 10  # Initial backoff in seconds between task retries
+
+AUTO_SAVE_LOG_NAME = "auto_save_tool_log.ndjson"
+
+
+def write_auto_save(
+    auto_save_dir: str,
+    turn: int,
+    tool_name: str,
+    result: str,
+) -> None:
+    """Append tool result to auto-save log (NDJSON, append-only, crash-safe)."""
+    try:
+        os.makedirs(auto_save_dir, exist_ok=True)
+        save_path = os.path.join(auto_save_dir, AUTO_SAVE_LOG_NAME)
+        entry = json.dumps({
+            "turn": turn,
+            "tool": tool_name,
+            "result_preview": (result or "")[:2000],
+        })
+        with open(save_path, "a") as f:
+            f.write(entry + "\n")
+    except Exception as e:
+        logging.warning(f"Auto-save failed: {e}")
+
+
+def read_tool_log(auto_save_dir: str) -> list[dict]:
+    """Read NDJSON auto-save log.  Skips malformed lines."""
+    if not auto_save_dir:
+        return []
+    entries: list[dict] = []
+    try:
+        path = os.path.join(auto_save_dir, AUTO_SAVE_LOG_NAME)
+        if os.path.exists(path):
+            with open(path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    with contextlib.suppress(json.JSONDecodeError):
+                        entries.append(json.loads(line))
+    except Exception:
+        logging.debug("Failed to read auto-save tool log", exc_info=True)
+    return entries
 
 
 def _resolve_model_config(
@@ -475,45 +520,11 @@ async def run_main(
     _auto_save_interval = int(os.getenv("AUTO_SAVE_INTERVAL", "0"))
     _auto_save_dir = os.getenv("AUTO_SAVE_DIR", "")
 
-    def _write_auto_save(tool_name: str, result: str) -> None:
-        """Append tool result to auto-save log (NDJSON, append-only, crash-safe)."""
-        try:
-            os.makedirs(_auto_save_dir, exist_ok=True)
-            save_path = os.path.join(_auto_save_dir, "auto_save_tool_log.ndjson")
-            entry = json.dumps({
-                "turn": _tool_call_counter[0],
-                "tool": tool_name,
-                "result_preview": (result or "")[:2000],
-            })
-            with open(save_path, "a") as f:
-                f.write(entry + "\n")
-        except Exception as e:
-            logging.warning(f"Auto-save failed: {e}")
-
-    def _read_tool_log() -> list[dict]:
-        """Read NDJSON auto-save log.  Skips malformed lines."""
-        if not _auto_save_dir:
-            return []
-        entries: list[dict] = []
-        try:
-            path = os.path.join(_auto_save_dir, "auto_save_tool_log.ndjson")
-            if os.path.exists(path):
-                with open(path) as f:
-                    for line in f:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        with contextlib.suppress(json.JSONDecodeError):
-                            entries.append(json.loads(line))
-        except Exception:
-            logging.debug("Failed to read auto-save tool log", exc_info=True)
-        return entries
-
     async def on_tool_end_hook(context: RunContextWrapper[TContext], agent: Agent[TContext], tool: Tool, result: str) -> None:
         last_mcp_tool_results.append(result)
         _tool_call_counter[0] += 1
         if _auto_save_dir and _auto_save_interval and _tool_call_counter[0] % _auto_save_interval == 0:
-            _write_auto_save(tool.name, result)
+            write_auto_save(_auto_save_dir, _tool_call_counter[0], tool.name, result)
 
     async def on_tool_start_hook(context: RunContextWrapper[TContext], agent: Agent[TContext], tool: Tool) -> None:
         await render_model_output(f"\n** 🤖🛠️ Tool Call: {tool.name}\n")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -484,8 +484,9 @@ class TestAutoSave:
         assert len(entries[0]["result_preview"]) == 2000
 
     def test_survives_write_failure(self):
-        """write_auto_save to an impossible path does not raise."""
-        write_auto_save("/dev/null/impossible", turn=1, tool_name="t", result="r")
+        """write_auto_save suppresses write errors without crashing."""
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            write_auto_save("/tmp/any", turn=1, tool_name="t", result="r")
 
     def test_read_skips_corrupt_trailing_line(self, tmp_path):
         """read_tool_log skips truncated/corrupt lines without discarding valid ones."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -441,3 +441,91 @@ class TestBuildPromptsToRun:
                     inputs={},
                 )
             )
+
+
+# ===================================================================
+# Auto-save scaffolding
+# ===================================================================
+
+
+class TestAutoSave:
+    """Tests for auto-save tool log scaffolding in run_main."""
+
+    @staticmethod
+    def _run_hook(monkeypatch, tmp_path, interval, calls):
+        """Set up auto-save env, import run_main to trigger closure, simulate tool calls."""
+        monkeypatch.setenv("AUTO_SAVE_DIR", str(tmp_path))
+        monkeypatch.setenv("AUTO_SAVE_INTERVAL", str(interval))
+
+        # We need to exercise the on_tool_end_hook closure.
+        # The simplest way is to import run_main, but the hook is a closure
+        # inside run_main that we can't call directly.  Instead, we test
+        # the _write_auto_save / _read_tool_log helpers indirectly by
+        # simulating what run_main does.
+        import importlib
+        import seclab_taskflow_agent.runner as runner_mod
+
+        importlib.reload(runner_mod)
+
+        # Construct the same state the closure would have.
+        counter = [0]
+        auto_dir = str(tmp_path)
+        auto_interval = interval
+
+        import os
+
+        os.makedirs(auto_dir, exist_ok=True)
+        save_path = os.path.join(auto_dir, "auto_save_tool_log.ndjson")
+
+        for tool_name, result in calls:
+            counter[0] += 1
+            if auto_dir and auto_interval and counter[0] % auto_interval == 0:
+                entry = json.dumps({
+                    "turn": counter[0],
+                    "tool": tool_name,
+                    "result_preview": (result or "")[:2000],
+                })
+                with open(save_path, "a") as f:
+                    f.write(entry + "\n")
+        return save_path
+
+    def test_disabled_by_default(self, monkeypatch, tmp_path):
+        """No log file created when interval is 0."""
+        import os
+
+        save_path = self._run_hook(monkeypatch, tmp_path, 0, [("tool_a", "res")])
+        assert not os.path.exists(save_path)
+
+    def test_writes_every_n_calls_when_enabled(self, monkeypatch, tmp_path):
+        """Log entries are written every N calls."""
+        calls = [(f"tool_{i}", f"result_{i}") for i in range(6)]
+        save_path = self._run_hook(monkeypatch, tmp_path, 3, calls)
+        with open(save_path) as f:
+            lines = [line.strip() for line in f if line.strip()]
+        assert len(lines) == 2  # calls 3 and 6
+
+    def test_log_format_has_turn_tool_preview(self, monkeypatch, tmp_path):
+        """Each NDJSON entry has the expected keys."""
+        calls = [("search_code", "found 5 matches")]
+        save_path = self._run_hook(monkeypatch, tmp_path, 1, calls)
+        with open(save_path) as f:
+            entry = json.loads(f.readline())
+        assert entry["turn"] == 1
+        assert entry["tool"] == "search_code"
+        assert entry["result_preview"] == "found 5 matches"
+
+    def test_result_truncated_to_2000(self, monkeypatch, tmp_path):
+        """Result preview is capped at 2000 characters."""
+        long_result = "x" * 5000
+        calls = [("big_tool", long_result)]
+        save_path = self._run_hook(monkeypatch, tmp_path, 1, calls)
+        with open(save_path) as f:
+            entry = json.loads(f.readline())
+        assert len(entry["result_preview"]) == 2000
+
+    def test_survives_write_failure(self):
+        """Auto-save to an impossible path does not raise."""
+        import os
+
+        save_path = os.path.join("/dev/null/impossible", "auto_save_tool_log.ndjson")
+        assert not os.path.exists(save_path)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -24,6 +24,8 @@ from seclab_taskflow_agent.runner import (
     _merge_reusable_task,
     _resolve_model_config,
     _resolve_task_model,
+    read_tool_log,
+    write_auto_save,
 )
 
 
@@ -449,83 +451,56 @@ class TestBuildPromptsToRun:
 
 
 class TestAutoSave:
-    """Tests for auto-save tool log scaffolding in run_main."""
+    """Tests for write_auto_save / read_tool_log (module-level functions)."""
 
-    @staticmethod
-    def _run_hook(monkeypatch, tmp_path, interval, calls):
-        """Set up auto-save env, import run_main to trigger closure, simulate tool calls."""
-        monkeypatch.setenv("AUTO_SAVE_DIR", str(tmp_path))
-        monkeypatch.setenv("AUTO_SAVE_INTERVAL", str(interval))
+    def test_disabled_when_no_dir(self):
+        """read_tool_log returns [] when dir is empty string."""
+        assert read_tool_log("") == []
 
-        # We need to exercise the on_tool_end_hook closure.
-        # The simplest way is to import run_main, but the hook is a closure
-        # inside run_main that we can't call directly.  Instead, we test
-        # the _write_auto_save / _read_tool_log helpers indirectly by
-        # simulating what run_main does.
-        import importlib
-        import seclab_taskflow_agent.runner as runner_mod
+    def test_write_then_read_roundtrip(self, tmp_path):
+        """write_auto_save produces entries that read_tool_log can read back."""
+        d = str(tmp_path)
+        write_auto_save(d, turn=1, tool_name="search_code", result="found 5")
+        write_auto_save(d, turn=2, tool_name="read_file", result="contents")
+        entries = read_tool_log(d)
+        assert len(entries) == 2
+        assert entries[0]["turn"] == 1
+        assert entries[0]["tool"] == "search_code"
+        assert entries[1]["turn"] == 2
 
-        importlib.reload(runner_mod)
-
-        # Construct the same state the closure would have.
-        counter = [0]
-        auto_dir = str(tmp_path)
-        auto_interval = interval
-
-        import os
-
-        os.makedirs(auto_dir, exist_ok=True)
-        save_path = os.path.join(auto_dir, "auto_save_tool_log.ndjson")
-
-        for tool_name, result in calls:
-            counter[0] += 1
-            if auto_dir and auto_interval and counter[0] % auto_interval == 0:
-                entry = json.dumps({
-                    "turn": counter[0],
-                    "tool": tool_name,
-                    "result_preview": (result or "")[:2000],
-                })
-                with open(save_path, "a") as f:
-                    f.write(entry + "\n")
-        return save_path
-
-    def test_disabled_by_default(self, monkeypatch, tmp_path):
-        """No log file created when interval is 0."""
-        import os
-
-        save_path = self._run_hook(monkeypatch, tmp_path, 0, [("tool_a", "res")])
-        assert not os.path.exists(save_path)
-
-    def test_writes_every_n_calls_when_enabled(self, monkeypatch, tmp_path):
-        """Log entries are written every N calls."""
-        calls = [(f"tool_{i}", f"result_{i}") for i in range(6)]
-        save_path = self._run_hook(monkeypatch, tmp_path, 3, calls)
-        with open(save_path) as f:
-            lines = [line.strip() for line in f if line.strip()]
-        assert len(lines) == 2  # calls 3 and 6
-
-    def test_log_format_has_turn_tool_preview(self, monkeypatch, tmp_path):
+    def test_log_format_has_turn_tool_preview(self, tmp_path):
         """Each NDJSON entry has the expected keys."""
-        calls = [("search_code", "found 5 matches")]
-        save_path = self._run_hook(monkeypatch, tmp_path, 1, calls)
-        with open(save_path) as f:
-            entry = json.loads(f.readline())
-        assert entry["turn"] == 1
-        assert entry["tool"] == "search_code"
-        assert entry["result_preview"] == "found 5 matches"
+        d = str(tmp_path)
+        write_auto_save(d, turn=7, tool_name="search_code", result="found 5 matches")
+        entries = read_tool_log(d)
+        assert len(entries) == 1
+        assert entries[0] == {"turn": 7, "tool": "search_code", "result_preview": "found 5 matches"}
 
-    def test_result_truncated_to_2000(self, monkeypatch, tmp_path):
+    def test_result_truncated_to_2000(self, tmp_path):
         """Result preview is capped at 2000 characters."""
-        long_result = "x" * 5000
-        calls = [("big_tool", long_result)]
-        save_path = self._run_hook(monkeypatch, tmp_path, 1, calls)
-        with open(save_path) as f:
-            entry = json.loads(f.readline())
-        assert len(entry["result_preview"]) == 2000
+        d = str(tmp_path)
+        write_auto_save(d, turn=1, tool_name="big", result="x" * 5000)
+        entries = read_tool_log(d)
+        assert len(entries[0]["result_preview"]) == 2000
 
     def test_survives_write_failure(self):
-        """Auto-save to an impossible path does not raise."""
+        """write_auto_save to an impossible path does not raise."""
+        write_auto_save("/dev/null/impossible", turn=1, tool_name="t", result="r")
+
+    def test_read_skips_corrupt_trailing_line(self, tmp_path):
+        """read_tool_log skips truncated/corrupt lines without discarding valid ones."""
         import os
 
-        save_path = os.path.join("/dev/null/impossible", "auto_save_tool_log.ndjson")
-        assert not os.path.exists(save_path)
+        d = str(tmp_path)
+        write_auto_save(d, turn=1, tool_name="good", result="ok")
+        # Append a corrupt line simulating crash mid-write
+        log_path = os.path.join(d, "auto_save_tool_log.ndjson")
+        with open(log_path, "a") as f:
+            f.write('{"truncated\n')
+        entries = read_tool_log(d)
+        assert len(entries) == 1
+        assert entries[0]["tool"] == "good"
+
+    def test_read_empty_dir(self, tmp_path):
+        """read_tool_log on a dir with no log file returns []."""
+        assert read_tool_log(str(tmp_path)) == []


### PR DESCRIPTION
## Problem

When a long-running taskflow crashes or is interrupted, all intermediate tool results are lost. There is no way to inspect what the agent found before the failure. This makes post-mortem debugging and forensic recovery difficult, especially for security audit workflows that may run for 45+ minutes.

## Changes

### Auto-save infrastructure (`runner.py`)

Adds opt-in periodic tool-result logging via two environment variables:
- **`AUTO_SAVE_DIR`**: Directory where logs are written (empty = disabled)
- **`AUTO_SAVE_INTERVAL`**: Write every N tool calls (0 = disabled)

When both are set, every Nth tool completion appends an NDJSON entry to `{AUTO_SAVE_DIR}/auto_save_tool_log.ndjson` containing:
- `turn`: tool call counter
- `tool`: tool name
- `result_preview`: first 2000 chars of the result

**Design decisions:**
- **NDJSON format**: Each entry is a single line. Append-only — no read-modify-write, no corruption on crash mid-write, safe under concurrent tool completions. If the process dies mid-write, only the last line is truncated; all prior lines remain valid JSON.
- **Module-level functions**: `write_auto_save()` and `read_tool_log()` are extracted as importable, testable functions with explicit parameters. The `on_tool_end_hook` closure delegates to them.
- **Zero overhead when disabled**: `AUTO_SAVE_INTERVAL=0` (default) short-circuits before the modulo check. Invalid (non-numeric) interval values are caught and fall back to 0 with a warning.
- **Explicit UTF-8 encoding**: All file I/O uses `encoding="utf-8"` for cross-platform consistency.

### README documentation

Documents `AUTO_SAVE_DIR` and `AUTO_SAVE_INTERVAL` in the Session Recovery section.

### Tests (`test_runner.py`, 7 new tests)

All tests call the real `write_auto_save` and `read_tool_log` functions:
- Write-then-read roundtrip
- NDJSON entry format validation (turn, tool, result_preview keys)
- Result truncation to 2000 chars
- Write failure suppression (mocked `OSError`)
- Corrupt trailing line recovery
- Empty directory returns `[]`
- Disabled when dir is empty string