### PR TITLE
Pass globals context to env block template rendering

### DIFF
--- a/src/seclab_taskflow_agent/env_utils.py
+++ b/src/seclab_taskflow_agent/env_utils.py
@@ -12,14 +12,15 @@ __all__ = ["TmpEnv", "swap_env"]
 
 
 
-def swap_env(s: str) -> str:
-    """Replace {{ env('VAR') }} patterns in string with environment values.
+def swap_env(s: str, context: dict[str, Any] | None = None) -> str:
+    """Replace {{ env('VAR') }} and {{ globals.X }} patterns in string.
 
     Args:
-        s: String potentially containing env templates
+        s: String potentially containing templates
+        context: Optional template context (e.g. {'globals': {...}})
 
     Returns:
-        String with env templates replaced
+        String with templates replaced
 
     Raises:
         LookupError: If required env var not found
@@ -36,7 +37,7 @@ def swap_env(s: str) -> str:
         available_tools = AvailableTools()
         jinja_env = create_jinja_environment(available_tools)
         template = jinja_env.from_string(s)
-        return template.render()
+        return template.render(**(context or {}))
     except jinja2.UndefinedError as e:
         # Convert Jinja undefined to LookupError for compatibility
         raise LookupError(str(e))
@@ -48,13 +49,15 @@ def swap_env(s: str) -> str:
 class TmpEnv:
     """Context manager that temporarily sets environment variables."""
 
-    def __init__(self, env: dict[str, str]) -> None:
+    def __init__(self, env: dict[str, str],
+                 context: dict[str, Any] | None = None) -> None:
         self.env = dict(env)
+        self.context = context
         self.restore_env = dict(os.environ)
 
     def __enter__(self) -> None:
         for k, v in self.env.items():
-            os.environ[k] = swap_env(v)
+            os.environ[k] = swap_env(v, self.context)
 
     def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any | None) -> None:
         for k, v in self.env.items():

--- a/src/seclab_taskflow_agent/env_utils.py
+++ b/src/seclab_taskflow_agent/env_utils.py
@@ -13,17 +13,23 @@ __all__ = ["TmpEnv", "swap_env"]
 
 
 def swap_env(s: str, context: dict[str, Any] | None = None) -> str:
-    """Replace {{ env('VAR') }} and {{ globals.X }} patterns in string.
+    """Render Jinja template expressions in a string.
+
+    Supports expressions such as ``{{ env('VAR') }}``. Template variables
+    like ``{{ globals.X }}`` are only available when provided by the caller
+    via ``context`` (e.g. ``{'globals': {...}}``).
 
     Args:
-        s: String potentially containing templates
-        context: Optional template context (e.g. {'globals': {...}})
+        s: String potentially containing templates.
+        context: Optional template context. Variables such as ``globals``
+            must be supplied here to be available during rendering.
 
     Returns:
-        String with templates replaced
+        String with templates replaced.
 
     Raises:
-        LookupError: If required env var not found
+        LookupError: If a required environment variable or template
+            variable is not found during rendering.
     """
     # Quick check if templating needed
     if '{{' not in s:
@@ -37,7 +43,14 @@ def swap_env(s: str, context: dict[str, Any] | None = None) -> str:
         available_tools = AvailableTools()
         jinja_env = create_jinja_environment(available_tools)
         template = jinja_env.from_string(s)
-        return template.render(**(context or {}))
+        # Filter out keys that collide with built-in template globals
+        # (e.g. the env() helper) to prevent callers from breaking them.
+        reserved_keys = set(jinja_env.globals)
+        render_context = {
+            key: value for key, value in (context or {}).items()
+            if key not in reserved_keys
+        }
+        return template.render(**render_context)
     except jinja2.UndefinedError as e:
         # Convert Jinja undefined to LookupError for compatibility
         raise LookupError(str(e))

--- a/src/seclab_taskflow_agent/env_utils.py
+++ b/src/seclab_taskflow_agent/env_utils.py
@@ -31,12 +31,7 @@ def swap_env(s: str, context: dict[str, Any] | None = None) -> str:
         LookupError: If a required environment variable or template
             variable is not found during rendering.
     """
-    # Quick check if templating needed
-    if '{{' not in s:
-        return s
-
     try:
-        # Import here to avoid circular dependency
         from .template_utils import create_jinja_environment
         from .available_tools import AvailableTools
 
@@ -52,11 +47,9 @@ def swap_env(s: str, context: dict[str, Any] | None = None) -> str:
         }
         return template.render(**render_context)
     except jinja2.UndefinedError as e:
-        # Convert Jinja undefined to LookupError for compatibility
         raise LookupError(str(e))
-    except jinja2.TemplateError:
-        # Not a template or failed to render, return as-is
-        return s
+    except jinja2.TemplateError as e:
+        raise LookupError(f"Template rendering failed for: {s!r}: {e}")
 
 
 class TmpEnv:
@@ -69,8 +62,18 @@ class TmpEnv:
         self.restore_env = dict(os.environ)
 
     def __enter__(self) -> None:
-        for k, v in self.env.items():
-            os.environ[k] = swap_env(v, self.context)
+        applied: list[str] = []
+        try:
+            for k, v in self.env.items():
+                os.environ[k] = swap_env(v, self.context)
+                applied.append(k)
+        except Exception:
+            for k in applied:
+                if k in self.restore_env:
+                    os.environ[k] = self.restore_env[k]
+                else:
+                    os.environ.pop(k, None)
+            raise
 
     def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any | None) -> None:
         for k, v in self.env.items():

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -579,7 +579,7 @@ async def run_main(
                     logging.error(f"Template rendering error: {e}")
                     raise ValueError(f"Failed to render prompt template: {e}") from e
 
-            with TmpEnv(env):
+            with TmpEnv(env, context={"globals": global_variables}):
                 prompts_to_run: list[str] = await _build_prompts_to_run(
                     task_prompt, repeat_prompt, last_mcp_tool_results,
                     available_tools, global_variables, inputs,

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -4,14 +4,13 @@
 """Tests for env_utils: swap_env and TmpEnv with globals context."""
 
 import os
-import unittest
 
 import pytest
 
 from seclab_taskflow_agent.env_utils import TmpEnv, swap_env
 
 
-class TestSwapEnv(unittest.TestCase):
+class TestSwapEnv:
     """Tests for swap_env template rendering."""
 
     def test_plain_string_unchanged(self):
@@ -51,7 +50,7 @@ class TestSwapEnv(unittest.TestCase):
         assert swap_env("plain") == "plain"
 
 
-class TestTmpEnv(unittest.TestCase):
+class TestTmpEnv:
     """Tests for TmpEnv context manager with globals."""
 
     def test_globals_rendered_in_env_block(self):
@@ -77,3 +76,11 @@ class TestTmpEnv(unittest.TestCase):
             assert os.environ["RESTORE_TEST"] == "overwritten"
         assert os.environ["RESTORE_TEST"] == "original"
         del os.environ["RESTORE_TEST"]
+
+    def test_tmpenv_rollback_on_error(self):
+        """Partial env modification is rolled back if swap_env raises."""
+        env = {"GOOD_KEY": "value", "BAD_KEY": "{{ globals.missing }}"}
+        with pytest.raises(LookupError), TmpEnv(env):
+            pass
+        assert "GOOD_KEY" not in os.environ
+        assert "BAD_KEY" not in os.environ

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: GitHub, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for env_utils: swap_env and TmpEnv with globals context."""
+
+import os
+import unittest
+
+from seclab_taskflow_agent.env_utils import TmpEnv, swap_env
+
+
+class TestSwapEnv(unittest.TestCase):
+    """Tests for swap_env template rendering."""
+
+    def test_plain_string_unchanged(self):
+        assert swap_env("no templates here") == "no templates here"
+
+    def test_env_function_works(self):
+        os.environ["TEST_SWAP_ENV_VAR"] = "hello"
+        try:
+            assert swap_env('{{ env("TEST_SWAP_ENV_VAR") }}') == "hello"
+        finally:
+            del os.environ["TEST_SWAP_ENV_VAR"]
+
+    def test_globals_with_context(self):
+        result = swap_env(
+            "key-{{ globals.ghsa_id }}",
+            context={"globals": {"ghsa_id": "GHSA-1234"}},
+        )
+        assert result == "key-GHSA-1234"
+
+    def test_globals_without_context_raises(self):
+        with self.assertRaises(LookupError):
+            swap_env("{{ globals.missing }}")
+
+    def test_context_cannot_override_env_helper(self):
+        """Passing an 'env' key in context must not shadow the env() function."""
+        os.environ["TEST_SWAP_RESERVED"] = "works"
+        try:
+            result = swap_env(
+                '{{ env("TEST_SWAP_RESERVED") }}',
+                context={"env": "should be filtered"},
+            )
+            assert result == "works"
+        finally:
+            del os.environ["TEST_SWAP_RESERVED"]
+
+    def test_no_context_backward_compat(self):
+        assert swap_env("plain") == "plain"
+
+
+class TestTmpEnv(unittest.TestCase):
+    """Tests for TmpEnv context manager with globals."""
+
+    def test_globals_rendered_in_env_block(self):
+        env = {"MY_KEY": "pvr-{{ globals.ghsa }}"}
+        ctx = {"globals": {"ghsa": "GHSA-5678"}}
+        with TmpEnv(env, context=ctx):
+            assert os.environ["MY_KEY"] == "pvr-GHSA-5678"
+        assert "MY_KEY" not in os.environ
+
+    def test_env_function_still_works_in_tmpenv(self):
+        os.environ["SOURCE_VAR"] = "value"
+        try:
+            env = {"DEST_VAR": '{{ env("SOURCE_VAR") }}'}
+            with TmpEnv(env):
+                assert os.environ["DEST_VAR"] == "value"
+        finally:
+            del os.environ["SOURCE_VAR"]
+
+    def test_tmpenv_restores_original(self):
+        os.environ["RESTORE_TEST"] = "original"
+        env = {"RESTORE_TEST": "overwritten"}
+        with TmpEnv(env):
+            assert os.environ["RESTORE_TEST"] == "overwritten"
+        assert os.environ["RESTORE_TEST"] == "original"
+        del os.environ["RESTORE_TEST"]

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -6,6 +6,8 @@
 import os
 import unittest
 
+import pytest
+
 from seclab_taskflow_agent.env_utils import TmpEnv, swap_env
 
 
@@ -30,7 +32,7 @@ class TestSwapEnv(unittest.TestCase):
         assert result == "key-GHSA-1234"
 
     def test_globals_without_context_raises(self):
-        with self.assertRaises(LookupError):
+        with pytest.raises(LookupError):
             swap_env("{{ globals.missing }}")
 
     def test_context_cannot_override_env_helper(self):


### PR DESCRIPTION
## Problem

Task `env:` blocks use `swap_env()` for template rendering, but `swap_env` only has access to the `env()` function -- not `globals`. This means `{{ globals.X }}` references in env blocks raise `UndefinedError`, even though they work fine in `user_prompt` blocks.

This matters for taskflows that need to pass global variables into container configuration (e.g. using a GHSA ID as a container persist key).

## Fix

- `swap_env()` now accepts an optional `context` dict
- `TmpEnv` accepts and forwards `context` to `swap_env()`
- The runner passes `{'globals': global_variables}` when constructing `TmpEnv`

Backward compatible: `context` defaults to `None`, all existing `env()` calls work unchanged.