### PR TITLE
WIP: Architecture Refactoring POC (Factory, Runner modules, MCP Registry)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ dependencies = [
   "starlette==0.49.1",
   "strenum==0.4.15",
   "tqdm==4.67.1",
+  "tenacity>=8.0.0",
   "typer==0.16.0",
   "types-requests==2.32.4.20250611",
   "typing-inspection==0.4.1",

--- a/src/seclab_taskflow_agent/agent.py
+++ b/src/seclab_taskflow_agent/agent.py
@@ -22,24 +22,15 @@ from agents import (
 )
 from agents.agent import FunctionToolResult, ModelSettings, ToolsToFinalOutputResult
 from agents.run import DEFAULT_MAX_TURNS
-from dotenv import find_dotenv, load_dotenv
 from openai import AsyncOpenAI
 
-from .capi import get_AI_endpoint, get_AI_token, get_provider
+from .capi import get_AI_endpoint, get_AI_token, get_default_model, get_provider
 
 __all__ = [
-    "DEFAULT_MODEL",
     "TaskAgent",
     "TaskAgentHooks",
     "TaskRunHooks",
 ]
-
-# grab our secrets from .env, this must be in .gitignore
-load_dotenv(find_dotenv(usecwd=True))
-
-api_endpoint = get_AI_endpoint()
-_default_provider = get_provider(api_endpoint)
-DEFAULT_MODEL = os.getenv("COPILOT_DEFAULT_MODEL", default=_default_provider.default_model)
 
 
 class TaskRunHooks(RunHooks):
@@ -152,7 +143,7 @@ class TaskAgent:
         handoffs: list[Any] | None = None,
         exclude_from_context: bool = False,
         mcp_servers: list[Any] | None = None,
-        model: str = DEFAULT_MODEL,
+        model: str | None = None,
         model_settings: ModelSettings | None = None,
         api_type: str = "chat_completions",
         endpoint: str | None = None,
@@ -168,7 +159,8 @@ class TaskAgent:
             token: Optional env var name whose value is used as the API key.
         """
         # Resolve per-model endpoint and token, falling back to defaults
-        resolved_endpoint = endpoint or api_endpoint
+        resolved_endpoint = endpoint or get_AI_endpoint()
+        resolved_model = model or get_default_model(resolved_endpoint)
         if token:
             resolved_token = os.getenv(token, "")
             if not resolved_token:
@@ -194,9 +186,9 @@ class TaskAgent:
 
         # Select model class based on api_type
         if api_type == "responses":
-            model_impl = OpenAIResponsesModel(model=model, openai_client=client)
+            model_impl = OpenAIResponsesModel(model=resolved_model, openai_client=client)
         else:
-            model_impl = OpenAIChatCompletionsModel(model=model, openai_client=client)
+            model_impl = OpenAIChatCompletionsModel(model=resolved_model, openai_client=client)
 
         self.agent = Agent(
             name=name,

--- a/src/seclab_taskflow_agent/capi.py
+++ b/src/seclab_taskflow_agent/capi.py
@@ -22,12 +22,16 @@ from typing import Any
 from urllib.parse import urlparse
 
 import httpx
+from dotenv import find_dotenv, load_dotenv
+
+load_dotenv(find_dotenv(usecwd=True))
 
 __all__ = [
     "COPILOT_INTEGRATION_ID",
     "APIProvider",
     "get_AI_endpoint",
     "get_AI_token",
+    "get_default_model",
     "get_provider",
     "list_capi_models",
     "list_tool_call_models",
@@ -172,6 +176,11 @@ def get_provider(endpoint: str | None = None) -> APIProvider:
 
     # Unknown endpoint — return a generic provider with the given base URL
     return APIProvider(name="custom", base_url=url, default_model="please-set-default-model-via-env")
+
+def get_default_model(endpoint: str | None = None) -> str:
+    """Return the default model for the given endpoint, allowing env overrides."""
+    provider = get_provider(endpoint)
+    return os.getenv("COPILOT_DEFAULT_MODEL", default=provider.default_model)
 
 
 # ---------------------------------------------------------------------------

--- a/src/seclab_taskflow_agent/capi.py
+++ b/src/seclab_taskflow_agent/capi.py
@@ -22,9 +22,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 import httpx
-from dotenv import find_dotenv, load_dotenv
-
-load_dotenv(find_dotenv(usecwd=True))
 
 __all__ = [
     "COPILOT_INTEGRATION_ID",

--- a/src/seclab_taskflow_agent/cli.py
+++ b/src/seclab_taskflow_agent/cli.py
@@ -19,6 +19,10 @@ import traceback
 from typing import Annotated
 
 import typer
+from dotenv import find_dotenv, load_dotenv
+
+# Load .env early, before any provider/env-var reads happen in imported modules.
+load_dotenv(find_dotenv(usecwd=True))
 
 from .available_tools import AvailableTools
 from .banner import get_banner

--- a/src/seclab_taskflow_agent/mcp_lifecycle.py
+++ b/src/seclab_taskflow_agent/mcp_lifecycle.py
@@ -13,7 +13,7 @@ __all__ = ["MCP_CLEANUP_TIMEOUT", "build_mcp_servers", "mcp_session_task"]
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 from agents.mcp import MCPServerSse, MCPServerStdio, MCPServerStreamableHttp, create_static_tool_filter
 
@@ -41,6 +41,80 @@ class MCPServerEntry:
         self.name = name
 
 
+# Type alias for a builder function
+MCPServerBuilder = Callable[[str, dict[str, Any], Any, int, list[str]], MCPServerEntry]
+
+MCP_TRANSPORT_REGISTRY: dict[str, MCPServerBuilder] = {}
+
+
+def register_transport(kind: str) -> Callable[[MCPServerBuilder], MCPServerBuilder]:
+    """Decorator to register an MCP transport builder."""
+    def decorator(builder: MCPServerBuilder) -> MCPServerBuilder:
+        MCP_TRANSPORT_REGISTRY[kind] = builder
+        return builder
+    return decorator
+
+
+@register_transport("stdio")
+def _build_stdio(tb: str, params: dict[str, Any], tool_filter: Any, client_session_timeout: int, confirms: list[str]) -> MCPServerEntry:
+    if params.get("reconnecting", False):
+        mcp_server = ReconnectingMCPServerStdio(
+            name=tb,
+            params=params,
+            tool_filter=tool_filter,
+            client_session_timeout_seconds=client_session_timeout,
+            cache_tools_list=True,
+        )
+    else:
+        mcp_server = MCPServerStdio(
+            name=tb,
+            params=params,
+            tool_filter=tool_filter,
+            client_session_timeout_seconds=client_session_timeout,
+            cache_tools_list=True,
+        )
+    return MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), None, name=tb)
+
+
+@register_transport("sse")
+def _build_sse(tb: str, params: dict[str, Any], tool_filter: Any, client_session_timeout: int, confirms: list[str]) -> MCPServerEntry:
+    mcp_server = MCPServerSse(
+        name=tb,
+        params=params,
+        tool_filter=tool_filter,
+        client_session_timeout_seconds=client_session_timeout,
+    )
+    return MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), None, name=tb)
+
+
+@register_transport("streamable")
+def _build_streamable(tb: str, params: dict[str, Any], tool_filter: Any, client_session_timeout: int, confirms: list[str]) -> MCPServerEntry:
+    server_proc = None
+    if "command" in params:
+
+        def _print_out(line: str) -> None:
+            logging.info(f"Streamable MCP Server stdout: {line}")
+
+        def _print_err(line: str) -> None:
+            logging.info(f"Streamable MCP Server stderr: {line}")
+
+        server_proc = StreamableMCPThread(
+            params["command"],
+            url=params["url"],
+            env=params["env"],
+            on_output=_print_out,
+            on_error=_print_err,
+        )
+    mcp_server = MCPServerStreamableHttp(
+        name=tb,
+        params=params,
+        tool_filter=tool_filter,
+        client_session_timeout_seconds=client_session_timeout,
+    )
+    return MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), server_proc, name=tb)
+
+
+
 def build_mcp_servers(
     available_tools: AvailableTools,
     toolboxes: list[str],
@@ -66,59 +140,13 @@ def build_mcp_servers(
         if headless:
             confirms = []
         client_session_timeout = client_session_timeout or DEFAULT_MCP_CLIENT_SESSION_TIMEOUT
-        server_proc = None
+        kind = params.get("kind")
+        builder = MCP_TRANSPORT_REGISTRY.get(kind)
+        if not builder:
+            raise ValueError(f"Unsupported MCP transport: {kind}")
 
-        match params["kind"]:
-            case "stdio":
-                if params.get("reconnecting", False):
-                    mcp_server = ReconnectingMCPServerStdio(
-                        name=tb,
-                        params=params,
-                        tool_filter=tool_filter,
-                        client_session_timeout_seconds=client_session_timeout,
-                        cache_tools_list=True,
-                    )
-                else:
-                    mcp_server = MCPServerStdio(
-                        name=tb,
-                        params=params,
-                        tool_filter=tool_filter,
-                        client_session_timeout_seconds=client_session_timeout,
-                        cache_tools_list=True,
-                    )
-            case "sse":
-                mcp_server = MCPServerSse(
-                    name=tb,
-                    params=params,
-                    tool_filter=tool_filter,
-                    client_session_timeout_seconds=client_session_timeout,
-                )
-            case "streamable":
-                if "command" in params:
-
-                    def _print_out(line: str) -> None:
-                        logging.info(f"Streamable MCP Server stdout: {line}")
-
-                    def _print_err(line: str) -> None:
-                        logging.info(f"Streamable MCP Server stderr: {line}")
-
-                    server_proc = StreamableMCPThread(
-                        params["command"],
-                        url=params["url"],
-                        env=params["env"],
-                        on_output=_print_out,
-                        on_error=_print_err,
-                    )
-                mcp_server = MCPServerStreamableHttp(
-                    name=tb,
-                    params=params,
-                    tool_filter=tool_filter,
-                    client_session_timeout_seconds=client_session_timeout,
-                )
-            case _:
-                raise ValueError(f"Unsupported MCP transport: {params['kind']}")
-
-        entries.append(MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), server_proc, name=tb))
+        entry = builder(tb, params, tool_filter, client_session_timeout, confirms)
+        entries.append(entry)
 
     return entries
 

--- a/src/seclab_taskflow_agent/mcp_lifecycle.py
+++ b/src/seclab_taskflow_agent/mcp_lifecycle.py
@@ -13,6 +13,7 @@ __all__ = ["MCP_CLEANUP_TIMEOUT", "build_mcp_servers", "mcp_session_task"]
 
 import asyncio
 import logging
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Callable
 
 from agents.mcp import MCPServerSse, MCPServerStdio, MCPServerStreamableHttp, create_static_tool_filter
@@ -114,6 +115,10 @@ def _build_streamable(tb: str, params: dict[str, Any], tool_filter: Any, client_
     return MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), server_proc, name=tb)
 
 
+# Freeze the registry after all transports are registered to prevent
+# accidental mutation in tests or at runtime.
+MCP_TRANSPORT_REGISTRY = MappingProxyType(MCP_TRANSPORT_REGISTRY)
+
 
 def build_mcp_servers(
     available_tools: AvailableTools,
@@ -141,9 +146,11 @@ def build_mcp_servers(
             confirms = []
         client_session_timeout = client_session_timeout or DEFAULT_MCP_CLIENT_SESSION_TIMEOUT
         kind = params.get("kind")
+        if kind is None:
+            raise ValueError(f"Missing 'kind' key in MCP params for toolbox {tb!r}")
         builder = MCP_TRANSPORT_REGISTRY.get(kind)
-        if not builder:
-            raise ValueError(f"Unsupported MCP transport: {kind}")
+        if builder is None:
+            raise ValueError(f"Unsupported MCP transport: {kind!r}")
 
         entry = builder(tb, params, tool_filter, client_session_timeout, confirms)
         entries.append(entry)

--- a/src/seclab_taskflow_agent/mcp_lifecycle.py
+++ b/src/seclab_taskflow_agent/mcp_lifecycle.py
@@ -9,11 +9,11 @@ used during taskflow execution.
 
 from __future__ import annotations
 
-__all__ = ["MCP_CLEANUP_TIMEOUT", "build_mcp_servers", "mcp_session_task"]
+__all__ = ["MCP_CLEANUP_TIMEOUT", "build_mcp_servers", "mcp_session_task", "register_transport"]
 
 import asyncio
 import logging
-from types import MappingProxyType
+
 from typing import TYPE_CHECKING, Any, Callable
 
 from agents.mcp import MCPServerSse, MCPServerStdio, MCPServerStreamableHttp, create_static_tool_filter
@@ -48,7 +48,7 @@ MCPServerBuilder = Callable[[str, dict[str, Any], Any, int, list[str]], MCPServe
 MCP_TRANSPORT_REGISTRY: dict[str, MCPServerBuilder] = {}
 
 
-def _register_transport(kind: str) -> Callable[[MCPServerBuilder], MCPServerBuilder]:
+def register_transport(kind: str) -> Callable[[MCPServerBuilder], MCPServerBuilder]:
     """Decorator to register an MCP transport builder."""
     def decorator(builder: MCPServerBuilder) -> MCPServerBuilder:
         MCP_TRANSPORT_REGISTRY[kind] = builder
@@ -56,7 +56,7 @@ def _register_transport(kind: str) -> Callable[[MCPServerBuilder], MCPServerBuil
     return decorator
 
 
-@_register_transport("stdio")
+@register_transport("stdio")
 def _build_stdio(tb: str, params: dict[str, Any], tool_filter: Any, client_session_timeout: int, confirms: list[str]) -> MCPServerEntry:
     if params.get("reconnecting", False):
         mcp_server = ReconnectingMCPServerStdio(
@@ -77,7 +77,7 @@ def _build_stdio(tb: str, params: dict[str, Any], tool_filter: Any, client_sessi
     return MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), None, name=tb)
 
 
-@_register_transport("sse")
+@register_transport("sse")
 def _build_sse(tb: str, params: dict[str, Any], tool_filter: Any, client_session_timeout: int, confirms: list[str]) -> MCPServerEntry:
     mcp_server = MCPServerSse(
         name=tb,
@@ -88,7 +88,7 @@ def _build_sse(tb: str, params: dict[str, Any], tool_filter: Any, client_session
     return MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), None, name=tb)
 
 
-@_register_transport("streamable")
+@register_transport("streamable")
 def _build_streamable(tb: str, params: dict[str, Any], tool_filter: Any, client_session_timeout: int, confirms: list[str]) -> MCPServerEntry:
     server_proc = None
     if "command" in params:
@@ -113,11 +113,6 @@ def _build_streamable(tb: str, params: dict[str, Any], tool_filter: Any, client_
         client_session_timeout_seconds=client_session_timeout,
     )
     return MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), server_proc, name=tb)
-
-
-# Freeze the registry after all transports are registered to prevent
-# accidental mutation in tests or at runtime.
-MCP_TRANSPORT_REGISTRY = MappingProxyType(MCP_TRANSPORT_REGISTRY)
 
 
 def build_mcp_servers(

--- a/src/seclab_taskflow_agent/mcp_lifecycle.py
+++ b/src/seclab_taskflow_agent/mcp_lifecycle.py
@@ -54,7 +54,7 @@ def register_transport(kind: str) -> Callable[[MCPServerBuilder], MCPServerBuild
         if kind in MCP_TRANSPORT_REGISTRY:
             raise ValueError(
                 f"MCP transport {kind!r} is already registered by {MCP_TRANSPORT_REGISTRY[kind].__name__!r}. "
-                "Use a unique kind name or unregister the existing builder first."
+                "Use a unique kind name."
             )
         MCP_TRANSPORT_REGISTRY[kind] = builder
         return builder

--- a/src/seclab_taskflow_agent/mcp_lifecycle.py
+++ b/src/seclab_taskflow_agent/mcp_lifecycle.py
@@ -48,7 +48,7 @@ MCPServerBuilder = Callable[[str, dict[str, Any], Any, int, list[str]], MCPServe
 MCP_TRANSPORT_REGISTRY: dict[str, MCPServerBuilder] = {}
 
 
-def register_transport(kind: str) -> Callable[[MCPServerBuilder], MCPServerBuilder]:
+def _register_transport(kind: str) -> Callable[[MCPServerBuilder], MCPServerBuilder]:
     """Decorator to register an MCP transport builder."""
     def decorator(builder: MCPServerBuilder) -> MCPServerBuilder:
         MCP_TRANSPORT_REGISTRY[kind] = builder
@@ -56,7 +56,7 @@ def register_transport(kind: str) -> Callable[[MCPServerBuilder], MCPServerBuild
     return decorator
 
 
-@register_transport("stdio")
+@_register_transport("stdio")
 def _build_stdio(tb: str, params: dict[str, Any], tool_filter: Any, client_session_timeout: int, confirms: list[str]) -> MCPServerEntry:
     if params.get("reconnecting", False):
         mcp_server = ReconnectingMCPServerStdio(
@@ -77,7 +77,7 @@ def _build_stdio(tb: str, params: dict[str, Any], tool_filter: Any, client_sessi
     return MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), None, name=tb)
 
 
-@register_transport("sse")
+@_register_transport("sse")
 def _build_sse(tb: str, params: dict[str, Any], tool_filter: Any, client_session_timeout: int, confirms: list[str]) -> MCPServerEntry:
     mcp_server = MCPServerSse(
         name=tb,
@@ -88,7 +88,7 @@ def _build_sse(tb: str, params: dict[str, Any], tool_filter: Any, client_session
     return MCPServerEntry(MCPNamespaceWrap(confirms, mcp_server), None, name=tb)
 
 
-@register_transport("streamable")
+@_register_transport("streamable")
 def _build_streamable(tb: str, params: dict[str, Any], tool_filter: Any, client_session_timeout: int, confirms: list[str]) -> MCPServerEntry:
     server_proc = None
     if "command" in params:

--- a/src/seclab_taskflow_agent/mcp_lifecycle.py
+++ b/src/seclab_taskflow_agent/mcp_lifecycle.py
@@ -51,6 +51,11 @@ MCP_TRANSPORT_REGISTRY: dict[str, MCPServerBuilder] = {}
 def register_transport(kind: str) -> Callable[[MCPServerBuilder], MCPServerBuilder]:
     """Decorator to register an MCP transport builder."""
     def decorator(builder: MCPServerBuilder) -> MCPServerBuilder:
+        if kind in MCP_TRANSPORT_REGISTRY:
+            raise ValueError(
+                f"MCP transport {kind!r} is already registered by {MCP_TRANSPORT_REGISTRY[kind].__name__!r}. "
+                "Use a unique kind name or unregister the existing builder first."
+            )
         MCP_TRANSPORT_REGISTRY[kind] = builder
         return builder
     return decorator

--- a/src/seclab_taskflow_agent/model_resolver.py
+++ b/src/seclab_taskflow_agent/model_resolver.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from .agent import DEFAULT_MODEL
 from .available_tools import AvailableTools
+from .capi import get_default_model
 from .models import ModelConfigDocument, TaskDefinition
 
 
-def _resolve_model_config(
+def resolve_model_config(
     available_tools: AvailableTools,
     model_config_ref: str,
 ) -> tuple[list[str], dict[str, str], dict[str, dict[str, Any]], str]:
@@ -46,7 +46,7 @@ def _resolve_model_config(
     return model_keys, model_dict, models_params, m_config.api_type
 
 
-def _resolve_task_model(
+def resolve_task_model(
     task: TaskDefinition,
     model_keys: list[str],
     model_dict: dict[str, str],
@@ -62,7 +62,7 @@ def _resolve_task_model(
     Raises:
         ValueError: If task-level model_settings is not a dictionary.
     """
-    logical_name: str = task.model or DEFAULT_MODEL
+    logical_name: str = task.model or get_default_model()
     model_settings: dict[str, Any] = {}
     api_type: str = default_api_type
     endpoint: str | None = None

--- a/src/seclab_taskflow_agent/model_resolver.py
+++ b/src/seclab_taskflow_agent/model_resolver.py
@@ -62,28 +62,35 @@ def resolve_task_model(
     Raises:
         ValueError: If task-level model_settings is not a dictionary.
     """
-    logical_name: str = task.model or get_default_model()
     model_settings: dict[str, Any] = {}
     api_type: str = default_api_type
     endpoint: str | None = None
     token: str | None = None
 
+    # Step 1: Peek at task-level settings to extract the endpoint override
+    # *before* resolving the default model, so get_default_model() receives
+    # the correct endpoint and picks the right provider's default model.
+    task_model_settings: dict[str, Any] | Any = task.model_settings or {}
+    if not isinstance(task_model_settings, dict):
+        raise ValueError(f"model_settings in task {task.name or ''} needs to be a dictionary")
+    task_settings = dict(task_model_settings)
+    preliminary_endpoint: str | None = task_settings.get("endpoint", None)
+
+    # Step 2: Resolve the logical model name, using the endpoint-aware default
+    logical_name: str = task.model or get_default_model(preliminary_endpoint)
+
+    # Step 3: Look up config-level settings for this logical name
     if logical_name in model_keys:
         if logical_name in models_params:
             model_settings = models_params[logical_name].copy()
         logical_name = model_dict[logical_name]
 
-    # Extract engine-level keys before merging task settings
+    # Step 4: Extract engine-level keys from config settings
     api_type = model_settings.pop("api_type", api_type)
     endpoint = model_settings.pop("endpoint", None)
     token = model_settings.pop("token", None)
 
-    task_model_settings: dict[str, Any] | Any = task.model_settings or {}
-    if not isinstance(task_model_settings, dict):
-        raise ValueError(f"model_settings in task {task.name or ''} needs to be a dictionary")
-
-    # Task-level overrides can also set engine keys
-    task_settings = dict(task_model_settings)
+    # Step 5: Apply task-level overrides (task wins over config)
     api_type = task_settings.pop("api_type", api_type)
     endpoint = task_settings.pop("endpoint", endpoint)
     token = task_settings.pop("token", token)

--- a/src/seclab_taskflow_agent/model_resolver.py
+++ b/src/seclab_taskflow_agent/model_resolver.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: GitHub, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Model resolution logic for Taskflow.
+
+Extracts model configuration and task-level overrides.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .agent import DEFAULT_MODEL
+from .available_tools import AvailableTools
+from .models import ModelConfigDocument, TaskDefinition
+
+
+def _resolve_model_config(
+    available_tools: AvailableTools,
+    model_config_ref: str,
+) -> tuple[list[str], dict[str, str], dict[str, dict[str, Any]], str]:
+    """Load and validate the model configuration file.
+
+    Args:
+        available_tools: Tool registry used to load the config file.
+        model_config_ref: Reference name for the model config document.
+
+    Returns:
+        A tuple of (model_keys, model_dict, models_params, api_type) where
+        model_keys is the list of logical model names, model_dict maps them
+        to provider model IDs, models_params holds per-model settings, and
+        api_type is ``"chat_completions"`` or ``"responses"``.
+
+    Raises:
+        ValueError: If the config file has structural problems.
+    """
+    m_config: ModelConfigDocument = available_tools.get_model_config(model_config_ref)
+    model_dict: dict[str, str] = m_config.models or {}
+    model_keys: list[str] = list(model_dict.keys())
+    models_params: dict[str, dict[str, Any]] = m_config.model_settings or {}
+    unknown = set(models_params) - set(model_keys)
+    if unknown:
+        raise ValueError(
+            f"Settings section of model_config file {model_config_ref} contains models not in the model section: {unknown}"
+        )
+    return model_keys, model_dict, models_params, m_config.api_type
+
+
+def _resolve_task_model(
+    task: TaskDefinition,
+    model_keys: list[str],
+    model_dict: dict[str, str],
+    models_params: dict[str, dict[str, Any]],
+    default_api_type: str = "chat_completions",
+) -> tuple[str, dict[str, Any], str, str | None, str | None]:
+    """Resolve the final model name, settings, and per-model overrides.
+
+    Returns:
+        A tuple of ``(model_id, model_settings, api_type, endpoint, token)``
+        where *endpoint* and *token* are ``None`` when not overridden.
+
+    Raises:
+        ValueError: If task-level model_settings is not a dictionary.
+    """
+    logical_name: str = task.model or DEFAULT_MODEL
+    model_settings: dict[str, Any] = {}
+    api_type: str = default_api_type
+    endpoint: str | None = None
+    token: str | None = None
+
+    if logical_name in model_keys:
+        if logical_name in models_params:
+            model_settings = models_params[logical_name].copy()
+        logical_name = model_dict[logical_name]
+
+    # Extract engine-level keys before merging task settings
+    api_type = model_settings.pop("api_type", api_type)
+    endpoint = model_settings.pop("endpoint", None)
+    token = model_settings.pop("token", None)
+
+    task_model_settings: dict[str, Any] | Any = task.model_settings or {}
+    if not isinstance(task_model_settings, dict):
+        raise ValueError(f"model_settings in task {task.name or ''} needs to be a dictionary")
+
+    # Task-level overrides can also set engine keys
+    task_settings = dict(task_model_settings)
+    api_type = task_settings.pop("api_type", api_type)
+    endpoint = task_settings.pop("endpoint", endpoint)
+    token = task_settings.pop("token", token)
+
+    model_settings.update(task_settings)
+    return logical_name, model_settings, api_type, endpoint, token

--- a/src/seclab_taskflow_agent/prompt_builder.py
+++ b/src/seclab_taskflow_agent/prompt_builder.py
@@ -19,7 +19,7 @@ from .render_utils import render_model_output
 from .template_utils import render_template
 
 
-async def _build_prompts_to_run(
+async def build_prompts_to_run(
     task_prompt: str,
     repeat_prompt: bool,
     last_mcp_tool_results: list[str],

--- a/src/seclab_taskflow_agent/prompt_builder.py
+++ b/src/seclab_taskflow_agent/prompt_builder.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: GitHub, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Prompt building logic for Taskflow.
+
+Handles Jinja2 templating and prompt iteration based on MCP tool results.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import jinja2
+
+from .available_tools import AvailableTools
+from .render_utils import render_model_output
+from .template_utils import render_template
+
+
+async def _build_prompts_to_run(
+    task_prompt: str,
+    repeat_prompt: bool,
+    last_mcp_tool_results: list[str],
+    available_tools: AvailableTools,
+    global_variables: dict[str, Any],
+    inputs: dict[str, Any],
+) -> list[str]:
+    """Build the list of prompts to execute for a task.
+
+    For regular tasks the list contains a single rendered prompt.  When
+    ``repeat_prompt`` is enabled, the last MCP tool result is parsed as an
+    iterable and a prompt is rendered for each element.
+
+    Args:
+        task_prompt: The raw or pre-rendered prompt template string.
+        repeat_prompt: Whether to expand prompts over MCP tool results.
+        last_mcp_tool_results: Mutable list of prior MCP tool result strings.
+        available_tools: Tool registry (passed through to template rendering).
+        global_variables: Global template variables.
+        inputs: Task-level input variables.
+
+    Returns:
+        List of rendered prompt strings to execute.
+
+    Raises:
+        ValueError: If the last MCP result is missing or not valid JSON.
+    """
+    prompts_to_run: list[str] = []
+    if repeat_prompt:
+        if "result" not in task_prompt.lower():
+            logging.warning("repeat_prompt enabled but no {{ result }} in prompt")
+        try:
+            last_result = json.loads(last_mcp_tool_results[-1])
+        except IndexError:
+            logging.critical("No last MCP tool result available")
+            raise
+        except json.JSONDecodeError as exc:
+            logging.critical(f"Could not parse tool result as JSON: {last_mcp_tool_results[-1][:200]}")
+            raise ValueError("Tool result is not valid JSON") from exc
+
+        text = last_result.get("text", "")
+        try:
+            iterable_result = json.loads(text)
+        except json.JSONDecodeError as exc:
+            logging.critical(f"Could not parse result text: {text}")
+            raise ValueError("Result text is not valid JSON") from exc
+        try:
+            iter(iterable_result)
+        except TypeError:
+            logging.critical("Last MCP tool result is not iterable")
+            raise
+
+        if not iterable_result:
+            await render_model_output("** 🤖❗MCP tool result iterable is empty!\n")
+        else:
+            logging.debug(f"Rendering templated prompts for results: {iterable_result}")
+            for value in iterable_result:
+                try:
+                    rendered_prompt = render_template(
+                        template_str=task_prompt,
+                        available_tools=available_tools,
+                        globals_dict=global_variables,
+                        inputs_dict=inputs,
+                        result_value=value,
+                    )
+                    prompts_to_run.append(rendered_prompt)
+                except jinja2.TemplateError as e:
+                    logging.error(f"Error rendering template for result {value}: {e}")
+                    raise ValueError(f"Template rendering failed: {e}")
+
+        # Consume only after all prompts rendered successfully so that
+        # the result remains available for retry/resume on failure.
+        last_mcp_tool_results.pop()
+    else:
+        prompts_to_run.append(task_prompt)
+    return prompts_to_run

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -41,10 +41,10 @@ from .available_tools import AvailableTools
 from .env_utils import TmpEnv
 from .mcp_lifecycle import MCP_CLEANUP_TIMEOUT, build_mcp_servers, mcp_session_task
 from .models import ModelConfigDocument, PersonalityDocument, TaskDefinition
-from .model_resolver import resolve_model_config, resolve_task_model
+from .model_resolver import resolve_model_config, _resolve_task_model
 from .mcp_prompt import mcp_system_prompt
 from .mcp_utils import compress_name, mcp_client_params
-from .prompt_builder import build_prompts_to_run
+from .prompt_builder import _build_prompts_to_run
 from .render_utils import flush_async_output, render_model_output
 from .shell_utils import shell_tool_call
 from .template_utils import render_template
@@ -239,16 +239,9 @@ async def deploy_task_agents(
         try:
             complete = False
 
-            # Decorators are applied inside the function body so that each
-            # call to deploy_task_agents gets a fresh retry state.
             @retry(
-                retry=retry_if_exception_type(RateLimitError),
+                retry=retry_if_exception_type((RateLimitError, APITimeoutError)),
                 wait=wait_exponential(multiplier=RATE_LIMIT_BACKOFF, max=MAX_RATE_LIMIT_BACKOFF),
-                stop=stop_after_attempt(MAX_API_RETRY),
-                reraise=True,
-            )
-            @retry(
-                retry=retry_if_exception_type(APITimeoutError),
                 stop=stop_after_attempt(MAX_API_RETRY),
                 reraise=True,
             )
@@ -392,7 +385,7 @@ async def run_main(
                 task = _merge_reusable_task(available_tools, task)
 
             # Resolve model (name, settings, api_type, optional endpoint/token)
-            model, model_settings, task_api_type, task_endpoint, task_token = resolve_task_model(
+            model, model_settings, task_api_type, task_endpoint, task_token = _resolve_task_model(
                 task, model_keys, model_dict, models_params, default_api_type=api_type,
             )
 
@@ -428,7 +421,7 @@ async def run_main(
                     raise ValueError(f"Failed to render prompt template: {e}") from e
 
             with TmpEnv(env, context={"globals": global_variables}):
-                prompts_to_run: list[str] = await build_prompts_to_run(
+                prompts_to_run: list[str] = await _build_prompts_to_run(
                     task_prompt, repeat_prompt, last_mcp_tool_results,
                     available_tools, global_variables, inputs,
                 )
@@ -551,6 +544,9 @@ async def run_main(
                             )
                             last_task_error = None
                 except Exception as exc:
+                    if pending_retry_msg:
+                        await render_model_output(pending_retry_msg)
+                        pending_retry_msg = None
                     last_task_error = exc
                     logging.error(f"Task {task_name!r} failed: {exc}")
 

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -33,7 +33,7 @@ from agents.exceptions import AgentsException, MaxTurnsExceeded
 from agents.extensions.handoff_prompt import prompt_with_handoff_instructions
 from openai import APIConnectionError, APITimeoutError, BadRequestError, RateLimitError
 from openai.types.responses import ResponseTextDeltaEvent
-from tenacity import AsyncRetrying, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+from tenacity import AsyncRetrying, retry, retry_if_exception_type, retry_if_not_exception_type, stop_after_attempt, wait_exponential
 
 from .agent import TaskAgent, TaskAgentHooks, TaskRunHooks
 from .capi import get_default_model

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -40,7 +40,7 @@ from .capi import get_default_model
 from .available_tools import AvailableTools
 from .env_utils import TmpEnv
 from .mcp_lifecycle import MCP_CLEANUP_TIMEOUT, build_mcp_servers, mcp_session_task
-from .models import ModelConfigDocument, PersonalityDocument, TaskDefinition
+from .models import PersonalityDocument, TaskDefinition
 from .model_resolver import resolve_model_config, resolve_task_model
 from .mcp_prompt import mcp_system_prompt
 from .mcp_utils import compress_name, mcp_client_params

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -267,6 +267,9 @@ async def deploy_task_agents(
         except APITimeoutError as e:
             await render_model_output(f"** 🤖❗ Timeout Error: {e}\n", async_task=async_task, task_id=task_id)
             logging.exception("API Timeout")
+        except RateLimitError as e:
+            await render_model_output(f"** 🤖❗ Rate Limit Error: {e}\n", async_task=async_task, task_id=task_id)
+            logging.exception("Rate limit exceeded after retries")
 
         if async_task:
             await flush_async_output(task_id)
@@ -525,7 +528,7 @@ async def run_main(
 
                 try:
                     async for attempt in AsyncRetrying(
-                        retry=retry_if_exception_type((APIConnectionError, ConnectionError, TimeoutError)),
+                        retry=retry_if_exception_type((APIConnectionError, APITimeoutError, RateLimitError, ConnectionError, TimeoutError)),
                         stop=stop_after_attempt(TASK_RETRY_LIMIT),
                         wait=wait_exponential(multiplier=TASK_RETRY_BACKOFF, max=60),
                         before_sleep=before_sleep_log,

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -41,10 +41,10 @@ from .available_tools import AvailableTools
 from .env_utils import TmpEnv
 from .mcp_lifecycle import MCP_CLEANUP_TIMEOUT, build_mcp_servers, mcp_session_task
 from .models import ModelConfigDocument, PersonalityDocument, TaskDefinition
-from .model_resolver import resolve_model_config, _resolve_task_model
+from .model_resolver import resolve_model_config, resolve_task_model
 from .mcp_prompt import mcp_system_prompt
 from .mcp_utils import compress_name, mcp_client_params
-from .prompt_builder import _build_prompts_to_run
+from .prompt_builder import build_prompts_to_run
 from .render_utils import flush_async_output, render_model_output
 from .shell_utils import shell_tool_call
 from .template_utils import render_template
@@ -385,7 +385,7 @@ async def run_main(
                 task = _merge_reusable_task(available_tools, task)
 
             # Resolve model (name, settings, api_type, optional endpoint/token)
-            model, model_settings, task_api_type, task_endpoint, task_token = _resolve_task_model(
+            model, model_settings, task_api_type, task_endpoint, task_token = resolve_task_model(
                 task, model_keys, model_dict, models_params, default_api_type=api_type,
             )
 
@@ -421,7 +421,7 @@ async def run_main(
                     raise ValueError(f"Failed to render prompt template: {e}") from e
 
             with TmpEnv(env, context={"globals": global_variables}):
-                prompts_to_run: list[str] = await _build_prompts_to_run(
+                prompts_to_run: list[str] = await build_prompts_to_run(
                     task_prompt, repeat_prompt, last_mcp_tool_results,
                     available_tools, global_variables, inputs,
                 )

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -39,8 +39,10 @@ from .available_tools import AvailableTools
 from .env_utils import TmpEnv
 from .mcp_lifecycle import MCP_CLEANUP_TIMEOUT, build_mcp_servers, mcp_session_task
 from .models import ModelConfigDocument, PersonalityDocument, TaskDefinition
+from .model_resolver import _resolve_model_config, _resolve_task_model
 from .mcp_prompt import mcp_system_prompt
 from .mcp_utils import compress_name, mcp_client_params
+from .prompt_builder import _build_prompts_to_run
 from .render_utils import flush_async_output, render_model_output
 from .shell_utils import shell_tool_call
 from .template_utils import render_template
@@ -53,35 +55,6 @@ TASK_RETRY_LIMIT = 3  # Maximum retry attempts for a failed task
 TASK_RETRY_BACKOFF = 10  # Initial backoff in seconds between task retries
 
 
-def _resolve_model_config(
-    available_tools: AvailableTools,
-    model_config_ref: str,
-) -> tuple[list[str], dict[str, str], dict[str, dict[str, Any]], str]:
-    """Load and validate the model configuration file.
-
-    Args:
-        available_tools: Tool registry used to load the config file.
-        model_config_ref: Reference name for the model config document.
-
-    Returns:
-        A tuple of (model_keys, model_dict, models_params, api_type) where
-        model_keys is the list of logical model names, model_dict maps them
-        to provider model IDs, models_params holds per-model settings, and
-        api_type is ``"chat_completions"`` or ``"responses"``.
-
-    Raises:
-        ValueError: If the config file has structural problems.
-    """
-    m_config: ModelConfigDocument = available_tools.get_model_config(model_config_ref)
-    model_dict: dict[str, str] = m_config.models or {}
-    model_keys: list[str] = list(model_dict.keys())
-    models_params: dict[str, dict[str, Any]] = m_config.model_settings or {}
-    unknown = set(models_params) - set(model_keys)
-    if unknown:
-        raise ValueError(
-            f"Settings section of model_config file {model_config_ref} contains models not in the model section: {unknown}"
-        )
-    return model_keys, model_dict, models_params, m_config.api_type
 
 
 def _merge_reusable_task(
@@ -113,129 +86,6 @@ def _merge_reusable_task(
     return TaskDefinition.model_validate(merged)
 
 
-def _resolve_task_model(
-    task: TaskDefinition,
-    model_keys: list[str],
-    model_dict: dict[str, str],
-    models_params: dict[str, dict[str, Any]],
-    default_api_type: str = "chat_completions",
-) -> tuple[str, dict[str, Any], str, str | None, str | None]:
-    """Resolve the final model name, settings, and per-model overrides.
-
-    Returns:
-        A tuple of ``(model_id, model_settings, api_type, endpoint, token)``
-        where *endpoint* and *token* are ``None`` when not overridden.
-
-    Raises:
-        ValueError: If task-level model_settings is not a dictionary.
-    """
-    logical_name: str = task.model or DEFAULT_MODEL
-    model_settings: dict[str, Any] = {}
-    api_type: str = default_api_type
-    endpoint: str | None = None
-    token: str | None = None
-
-    if logical_name in model_keys:
-        if logical_name in models_params:
-            model_settings = models_params[logical_name].copy()
-        logical_name = model_dict[logical_name]
-
-    # Extract engine-level keys before merging task settings
-    api_type = model_settings.pop("api_type", api_type)
-    endpoint = model_settings.pop("endpoint", None)
-    token = model_settings.pop("token", None)
-
-    task_model_settings: dict[str, Any] | Any = task.model_settings or {}
-    if not isinstance(task_model_settings, dict):
-        raise ValueError(f"model_settings in task {task.name or ''} needs to be a dictionary")
-
-    # Task-level overrides can also set engine keys
-    task_settings = dict(task_model_settings)
-    api_type = task_settings.pop("api_type", api_type)
-    endpoint = task_settings.pop("endpoint", endpoint)
-    token = task_settings.pop("token", token)
-
-    model_settings.update(task_settings)
-    return logical_name, model_settings, api_type, endpoint, token
-
-
-async def _build_prompts_to_run(
-    task_prompt: str,
-    repeat_prompt: bool,
-    last_mcp_tool_results: list[str],
-    available_tools: AvailableTools,
-    global_variables: dict[str, Any],
-    inputs: dict[str, Any],
-) -> list[str]:
-    """Build the list of prompts to execute for a task.
-
-    For regular tasks the list contains a single rendered prompt.  When
-    ``repeat_prompt`` is enabled, the last MCP tool result is parsed as an
-    iterable and a prompt is rendered for each element.
-
-    Args:
-        task_prompt: The raw or pre-rendered prompt template string.
-        repeat_prompt: Whether to expand prompts over MCP tool results.
-        last_mcp_tool_results: Mutable list of prior MCP tool result strings.
-        available_tools: Tool registry (passed through to template rendering).
-        global_variables: Global template variables.
-        inputs: Task-level input variables.
-
-    Returns:
-        List of rendered prompt strings to execute.
-
-    Raises:
-        ValueError: If the last MCP result is missing or not valid JSON.
-    """
-    prompts_to_run: list[str] = []
-    if repeat_prompt:
-        if "result" not in task_prompt.lower():
-            logging.warning("repeat_prompt enabled but no {{ result }} in prompt")
-        try:
-            last_result = json.loads(last_mcp_tool_results[-1])
-        except IndexError:
-            logging.critical("No last MCP tool result available")
-            raise
-        except json.JSONDecodeError as exc:
-            logging.critical(f"Could not parse tool result as JSON: {last_mcp_tool_results[-1][:200]}")
-            raise ValueError("Tool result is not valid JSON") from exc
-
-        text = last_result.get("text", "")
-        try:
-            iterable_result = json.loads(text)
-        except json.JSONDecodeError as exc:
-            logging.critical(f"Could not parse result text: {text}")
-            raise ValueError("Result text is not valid JSON") from exc
-        try:
-            iter(iterable_result)
-        except TypeError:
-            logging.critical("Last MCP tool result is not iterable")
-            raise
-
-        if not iterable_result:
-            await render_model_output("** 🤖❗MCP tool result iterable is empty!\n")
-        else:
-            logging.debug(f"Rendering templated prompts for results: {iterable_result}")
-            for value in iterable_result:
-                try:
-                    rendered_prompt = render_template(
-                        template_str=task_prompt,
-                        available_tools=available_tools,
-                        globals_dict=global_variables,
-                        inputs_dict=inputs,
-                        result_value=value,
-                    )
-                    prompts_to_run.append(rendered_prompt)
-                except jinja2.TemplateError as e:
-                    logging.error(f"Error rendering template for result {value}: {e}")
-                    raise ValueError(f"Template rendering failed: {e}")
-
-        # Consume only after all prompts rendered successfully so that
-        # the result remains available for retry/resume on failure.
-        last_mcp_tool_results.pop()
-    else:
-        prompts_to_run.append(task_prompt)
-    return prompts_to_run
 
 
 async def deploy_task_agents(

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -33,6 +33,7 @@ from agents.exceptions import AgentsException, MaxTurnsExceeded
 from agents.extensions.handoff_prompt import prompt_with_handoff_instructions
 from openai import APIConnectionError, APITimeoutError, BadRequestError, RateLimitError
 from openai.types.responses import ResponseTextDeltaEvent
+from tenacity import AsyncRetrying, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from .agent import DEFAULT_MODEL, TaskAgent, TaskAgentHooks, TaskRunHooks
 from .available_tools import AvailableTools
@@ -235,31 +236,18 @@ async def deploy_task_agents(
         try:
             complete = False
 
+            @retry(
+                retry=retry_if_exception_type((APITimeoutError, RateLimitError)),
+                stop=stop_after_attempt(MAX_API_RETRY),
+                wait=wait_exponential(multiplier=RATE_LIMIT_BACKOFF, max=MAX_RATE_LIMIT_BACKOFF),
+                reraise=True
+            )
             async def _run_streamed() -> None:
-                max_retry = MAX_API_RETRY
-                rate_limit_backoff = RATE_LIMIT_BACKOFF
-                while rate_limit_backoff:
-                    try:
-                        result = agent0.run_streamed(prompt, max_turns=max_turns)
-                        async for event in result.stream_events():
-                            if event.type == "raw_response_event" and isinstance(event.data, ResponseTextDeltaEvent):
-                                await render_model_output(event.data.delta, async_task=async_task, task_id=task_id)
-                        await render_model_output("\n\n", async_task=async_task, task_id=task_id)
-                        return
-                    except APITimeoutError:
-                        if not max_retry:
-                            logging.exception("Max retries for APITimeoutError reached")
-                            raise
-                        max_retry -= 1
-                    except RateLimitError:
-                        if rate_limit_backoff == MAX_RATE_LIMIT_BACKOFF:
-                            raise APITimeoutError("Max rate limit backoff reached")
-                        if rate_limit_backoff > MAX_RATE_LIMIT_BACKOFF:
-                            rate_limit_backoff = MAX_RATE_LIMIT_BACKOFF
-                        else:
-                            rate_limit_backoff += rate_limit_backoff
-                        logging.exception(f"Hit rate limit ... holding for {rate_limit_backoff}")
-                        await asyncio.sleep(rate_limit_backoff)
+                result = agent0.run_streamed(prompt, max_turns=max_turns)
+                async for event in result.stream_events():
+                    if event.type == "raw_response_event" and isinstance(event.data, ResponseTextDeltaEvent):
+                        await render_model_output(event.data.delta, async_task=async_task, task_id=task_id)
+                await render_model_output("\n\n", async_task=async_task, task_id=task_id)
 
             await _run_streamed()
             complete = True
@@ -521,33 +509,35 @@ async def run_main(
                 task_complete = False
                 last_task_error: BaseException | None = None
 
-                for attempt in range(TASK_RETRY_LIMIT):
-                    try:
-                        task_complete = await run_prompts(
-                            async_task=async_task,
-                            max_concurrent_tasks=max_concurrent_tasks,
-                        )
-                        last_task_error = None
-                        break
-                    except (KeyboardInterrupt, SystemExit):
-                        raise
-                    except (APIConnectionError, APITimeoutError, ConnectionError, TimeoutError) as exc:
-                        last_task_error = exc
-                        remaining = TASK_RETRY_LIMIT - attempt - 1
-                        if remaining > 0:
-                            backoff = TASK_RETRY_BACKOFF * (attempt + 1)
-                            await render_model_output(
-                                f"** 🤖🔄 Task {task_name!r} failed: {exc}\n"
-                                f"** 🤖🔄 Retrying in {backoff}s ({remaining} attempts left)\n"
+                def before_sleep_log(retry_state):
+                    exc = retry_state.outcome.exception()
+                    attempt = retry_state.attempt_number
+                    remaining = TASK_RETRY_LIMIT - attempt
+                    backoff = retry_state.next_action.sleep
+                    msg = (
+                        f"** 🤖🔄 Task {task_name!r} failed: {exc}\n"
+                        f"** 🤖🔄 Retrying in {backoff}s ({remaining} attempts left)\n"
+                    )
+                    asyncio.create_task(render_model_output(msg))
+                    logging.warning(f"Task {task_name!r} attempt {attempt} failed: {exc}")
+
+                try:
+                    async for attempt in AsyncRetrying(
+                        retry=retry_if_exception_type((APIConnectionError, APITimeoutError, ConnectionError, TimeoutError)),
+                        stop=stop_after_attempt(TASK_RETRY_LIMIT),
+                        wait=wait_exponential(multiplier=TASK_RETRY_BACKOFF),
+                        before_sleep=before_sleep_log,
+                        reraise=True
+                    ):
+                        with attempt:
+                            task_complete = await run_prompts(
+                                async_task=async_task,
+                                max_concurrent_tasks=max_concurrent_tasks,
                             )
-                            logging.warning(f"Task {task_name!r} attempt {attempt + 1} failed: {exc}")
-                            await asyncio.sleep(backoff)
-                        else:
-                            logging.error(f"Task {task_name!r} failed after {TASK_RETRY_LIMIT} attempts: {exc}")
-                    except Exception as exc:
-                        last_task_error = exc
-                        logging.error(f"Task {task_name!r} failed (non-retriable): {exc}")
-                        break
+                            last_task_error = None
+                except Exception as exc:
+                    last_task_error = exc
+                    logging.error(f"Task {task_name!r} failed: {exc}")
 
                 # If all retries exhausted with an exception, save and re-raise
                 if last_task_error is not None:

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -35,15 +35,16 @@ from openai import APIConnectionError, APITimeoutError, BadRequestError, RateLim
 from openai.types.responses import ResponseTextDeltaEvent
 from tenacity import AsyncRetrying, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from .agent import DEFAULT_MODEL, TaskAgent, TaskAgentHooks, TaskRunHooks
+from .agent import TaskAgent, TaskAgentHooks, TaskRunHooks
+from .capi import get_default_model
 from .available_tools import AvailableTools
 from .env_utils import TmpEnv
 from .mcp_lifecycle import MCP_CLEANUP_TIMEOUT, build_mcp_servers, mcp_session_task
 from .models import ModelConfigDocument, PersonalityDocument, TaskDefinition
-from .model_resolver import _resolve_model_config, _resolve_task_model
+from .model_resolver import resolve_model_config, resolve_task_model
 from .mcp_prompt import mcp_system_prompt
 from .mcp_utils import compress_name, mcp_client_params
-from .prompt_builder import _build_prompts_to_run
+from .prompt_builder import build_prompts_to_run
 from .render_utils import flush_async_output, render_model_output
 from .shell_utils import shell_tool_call
 from .template_utils import render_template
@@ -100,7 +101,7 @@ async def deploy_task_agents(
     headless: bool = False,
     exclude_from_context: bool = False,
     max_turns: int = DEFAULT_MAX_TURNS,
-    model: str = DEFAULT_MODEL,
+    model: str | None = None,
     model_par: dict[str, Any] | None = None,
     api_type: str = "chat_completions",
     endpoint: str | None = None,
@@ -125,10 +126,12 @@ async def deploy_task_agents(
     toolboxes_override = toolboxes_override or []
     blocked_tools = blocked_tools or []
 
+    resolved_model = model or get_default_model(endpoint)
+
     task_id = str(uuid.uuid4())
     await render_model_output(f"** 🤖💪 Deploying Task Flow Agent(s): {list(agents.keys())}\n")
     await render_model_output(f"** 🤖💪 Task ID : {task_id}\n")
-    await render_model_output(f"** 🤖💪 Model   : {model}{', params: ' + str(model_par) if model_par else ''}\n")
+    await render_model_output(f"** 🤖💪 Model   : {resolved_model}{', params: ' + str(model_par) if model_par else ''}\n")
     if endpoint:
         await render_model_output(f"** 🤖💪 Endpoint: {endpoint}\n")
 
@@ -199,7 +202,7 @@ async def deploy_task_agents(
                     handoffs=[],
                     exclude_from_context=exclude_from_context,
                     mcp_servers=[e.server for e in entries],
-                    model=model,
+                    model=resolved_model,
                     model_settings=model_settings,
                     api_type=api_type,
                     endpoint=endpoint,
@@ -224,7 +227,7 @@ async def deploy_task_agents(
             handoffs=handoffs,
             exclude_from_context=exclude_from_context,
             mcp_servers=[e.server for e in entries],
-            model=model,
+            model=resolved_model,
             model_settings=model_settings,
             api_type=api_type,
             endpoint=endpoint,
@@ -236,11 +239,18 @@ async def deploy_task_agents(
         try:
             complete = False
 
+            # Decorators are applied inside the function body so that each
+            # call to deploy_task_agents gets a fresh retry state.
             @retry(
-                retry=retry_if_exception_type((APITimeoutError, RateLimitError)),
-                stop=stop_after_attempt(MAX_API_RETRY),
+                retry=retry_if_exception_type(RateLimitError),
                 wait=wait_exponential(multiplier=RATE_LIMIT_BACKOFF, max=MAX_RATE_LIMIT_BACKOFF),
-                reraise=True
+                stop=stop_after_attempt(MAX_API_RETRY),
+                reraise=True,
+            )
+            @retry(
+                retry=retry_if_exception_type(APITimeoutError),
+                stop=stop_after_attempt(MAX_API_RETRY),
+                reraise=True,
             )
             async def _run_streamed() -> None:
                 result = agent0.run_streamed(prompt, max_turns=max_turns)
@@ -354,7 +364,7 @@ async def run_main(
         models_params: dict[str, dict[str, Any]] = {}
         api_type: str = "chat_completions"
         if model_config_ref:
-            model_keys, model_dict, models_params, api_type = _resolve_model_config(available_tools, model_config_ref)
+            model_keys, model_dict, models_params, api_type = resolve_model_config(available_tools, model_config_ref)
 
         # Create session if this is a new run (not personality mode)
         if session is None:
@@ -382,7 +392,7 @@ async def run_main(
                 task = _merge_reusable_task(available_tools, task)
 
             # Resolve model (name, settings, api_type, optional endpoint/token)
-            model, model_settings, task_api_type, task_endpoint, task_token = _resolve_task_model(
+            model, model_settings, task_api_type, task_endpoint, task_token = resolve_task_model(
                 task, model_keys, model_dict, models_params, default_api_type=api_type,
             )
 
@@ -418,7 +428,7 @@ async def run_main(
                     raise ValueError(f"Failed to render prompt template: {e}") from e
 
             with TmpEnv(env, context={"globals": global_variables}):
-                prompts_to_run: list[str] = await _build_prompts_to_run(
+                prompts_to_run: list[str] = await build_prompts_to_run(
                     task_prompt, repeat_prompt, last_mcp_tool_results,
                     available_tools, global_variables, inputs,
                 )
@@ -509,16 +519,18 @@ async def run_main(
                 task_complete = False
                 last_task_error: BaseException | None = None
 
+                pending_retry_msg: str | None = None
+
                 def before_sleep_log(retry_state):
+                    nonlocal pending_retry_msg
                     exc = retry_state.outcome.exception()
                     attempt = retry_state.attempt_number
                     remaining = TASK_RETRY_LIMIT - attempt
                     backoff = retry_state.next_action.sleep
-                    msg = (
+                    pending_retry_msg = (
                         f"** 🤖🔄 Task {task_name!r} failed: {exc}\n"
                         f"** 🤖🔄 Retrying in {backoff}s ({remaining} attempts left)\n"
                     )
-                    asyncio.create_task(render_model_output(msg))
                     logging.warning(f"Task {task_name!r} attempt {attempt} failed: {exc}")
 
                 try:
@@ -530,6 +542,9 @@ async def run_main(
                         reraise=True
                     ):
                         with attempt:
+                            if pending_retry_msg:
+                                await render_model_output(pending_retry_msg)
+                                pending_retry_msg = None
                             task_complete = await run_prompts(
                                 async_task=async_task,
                                 max_concurrent_tasks=max_concurrent_tasks,

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -528,9 +528,9 @@ async def run_main(
 
                 try:
                     async for attempt in AsyncRetrying(
-                        retry=retry_if_exception_type((APIConnectionError, APITimeoutError, ConnectionError, TimeoutError)),
+                        retry=retry_if_exception_type((APIConnectionError, ConnectionError, TimeoutError)),
                         stop=stop_after_attempt(TASK_RETRY_LIMIT),
-                        wait=wait_exponential(multiplier=TASK_RETRY_BACKOFF),
+                        wait=wait_exponential(multiplier=TASK_RETRY_BACKOFF, max=60),
                         before_sleep=before_sleep_log,
                         reraise=True
                     ):

--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -33,7 +33,7 @@ from agents.exceptions import AgentsException, MaxTurnsExceeded
 from agents.extensions.handoff_prompt import prompt_with_handoff_instructions
 from openai import APIConnectionError, APITimeoutError, BadRequestError, RateLimitError
 from openai.types.responses import ResponseTextDeltaEvent
-from tenacity import AsyncRetrying, retry, retry_if_exception_type, retry_if_not_exception_type, stop_after_attempt, wait_exponential
+from tenacity import AsyncRetrying, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from .agent import TaskAgent, TaskAgentHooks, TaskRunHooks
 from .capi import get_default_model
@@ -512,19 +512,16 @@ async def run_main(
                 task_complete = False
                 last_task_error: BaseException | None = None
 
-                pending_retry_msg: str | None = None
-
-                def before_sleep_log(retry_state):
-                    nonlocal pending_retry_msg
+                async def before_sleep_log(retry_state) -> None:
                     exc = retry_state.outcome.exception()
                     attempt = retry_state.attempt_number
                     remaining = TASK_RETRY_LIMIT - attempt
                     backoff = retry_state.next_action.sleep
-                    pending_retry_msg = (
+                    logging.warning(f"Task {task_name!r} attempt {attempt} failed: {exc}")
+                    await render_model_output(
                         f"** 🤖🔄 Task {task_name!r} failed: {exc}\n"
                         f"** 🤖🔄 Retrying in {backoff}s ({remaining} attempts left)\n"
                     )
-                    logging.warning(f"Task {task_name!r} attempt {attempt} failed: {exc}")
 
                 try:
                     async for attempt in AsyncRetrying(
@@ -535,18 +532,12 @@ async def run_main(
                         reraise=True
                     ):
                         with attempt:
-                            if pending_retry_msg:
-                                await render_model_output(pending_retry_msg)
-                                pending_retry_msg = None
                             task_complete = await run_prompts(
                                 async_task=async_task,
                                 max_concurrent_tasks=max_concurrent_tasks,
                             )
                             last_task_error = None
                 except Exception as exc:
-                    if pending_retry_msg:
-                        await render_model_output(pending_retry_msg)
-                        pending_retry_msg = None
                     last_task_error = exc
                     logging.error(f"Task {task_name!r} failed: {exc}")
 

--- a/src/seclab_taskflow_agent/template_utils.py
+++ b/src/seclab_taskflow_agent/template_utils.py
@@ -56,7 +56,7 @@ class PromptLoader(jinja2.BaseLoader):
             raise jinja2.TemplateNotFound(template)
 
 
-def env_function(var_name: str, default: Optional[str] = None, required: bool = False) -> str:
+def env_function(var_name: str, default: Optional[str] = None, required: bool = True) -> str:
     """Jinja2 function to access environment variables.
 
     Args:

--- a/src/seclab_taskflow_agent/template_utils.py
+++ b/src/seclab_taskflow_agent/template_utils.py
@@ -56,7 +56,7 @@ class PromptLoader(jinja2.BaseLoader):
             raise jinja2.TemplateNotFound(template)
 
 
-def env_function(var_name: str, default: Optional[str] = None, required: bool = True) -> str:
+def env_function(var_name: str, default: Optional[str] = None, required: bool = False) -> str:
     """Jinja2 function to access environment variables.
 
     Args:

--- a/tests/test_prompt_parser_edge.py
+++ b/tests/test_prompt_parser_edge.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from seclab_taskflow_agent.available_tools import AvailableTools
 from seclab_taskflow_agent.prompt_parser import parse_prompt_args
@@ -18,6 +18,7 @@ def _tools() -> AvailableTools:
 class TestParsePromptArgs:
     """Tests for parse_prompt_args edge cases."""
 
+    @patch("sys.argv", ["main"])
     def test_none_prompt_returns_defaults(self):
         """None prompt causes argparse to read sys.argv; result still has 6 elements."""
         result = parse_prompt_args(_tools(), None)
@@ -28,6 +29,7 @@ class TestParsePromptArgs:
         assert p is None
         assert t is None
 
+    @patch("sys.argv", ["main"])
     def test_empty_string_returns_defaults(self):
         """Empty string prompt returns default values."""
         result = parse_prompt_args(_tools(), "")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -240,7 +240,7 @@ class TestResolveTaskModel:
         assert settings["temperature"] == 0.5
 
     def test_default_model_when_empty(self):
-        """Empty model string falls back to DEFAULT_MODEL."""
+        """Empty model string falls back to the provider default model."""
         from seclab_taskflow_agent.capi import get_default_model
 
         model_id, _, _, _, _ = resolve_task_model(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -20,10 +20,10 @@ from seclab_taskflow_agent.models import (
     TaskWrapper,
 )
 from seclab_taskflow_agent.runner import (
-    _build_prompts_to_run,
+    build_prompts_to_run,
     _merge_reusable_task,
-    _resolve_model_config,
-    _resolve_task_model,
+    resolve_model_config,
+    resolve_task_model,
 )
 
 
@@ -80,7 +80,7 @@ class TestResolveModelConfig:
         at.get_model_config.return_value = _make_model_config(
             models={"fast": "gpt-4o-mini", "smart": "gpt-4o"},
         )
-        keys, mdict, params, api_type = _resolve_model_config(at, "ref")
+        keys, mdict, params, api_type = resolve_model_config(at, "ref")
         assert set(keys) == {"fast", "smart"}
         assert mdict == {"fast": "gpt-4o-mini", "smart": "gpt-4o"}
         assert params == {}
@@ -93,7 +93,7 @@ class TestResolveModelConfig:
             models={"m1": "provider-model"},
             api_type="responses",
         )
-        _, _, _, api_type = _resolve_model_config(at, "ref")
+        _, _, _, api_type = resolve_model_config(at, "ref")
         assert api_type == "responses"
 
     def test_model_settings_extraction(self):
@@ -103,7 +103,7 @@ class TestResolveModelConfig:
             models={"m1": "provider-m1"},
             model_settings={"m1": {"temperature": 0.5}},
         )
-        _, _, params, _ = _resolve_model_config(at, "ref")
+        _, _, params, _ = resolve_model_config(at, "ref")
         assert params == {"m1": {"temperature": 0.5}}
 
     def test_validation_error_on_non_dict_settings(self):
@@ -186,7 +186,7 @@ class TestResolveTaskModel:
 
     def test_logical_name_mapped_to_provider_id(self):
         """A logical model name is resolved to the provider model ID."""
-        model_id, _, _, _, _ = _resolve_task_model(
+        model_id, _, _, _, _ = resolve_task_model(
             TaskDefinition(model="fast"),
             model_keys=["fast"],
             model_dict={"fast": "gpt-4o-mini"},
@@ -196,7 +196,7 @@ class TestResolveTaskModel:
 
     def test_model_settings_from_config(self):
         """Settings from models_params are included in the result."""
-        _, settings, _, _, _ = _resolve_task_model(
+        _, settings, _, _, _ = resolve_task_model(
             TaskDefinition(model="fast"),
             model_keys=["fast"],
             model_dict={"fast": "gpt-4o-mini"},
@@ -207,7 +207,7 @@ class TestResolveTaskModel:
 
     def test_task_level_settings_override_config(self):
         """Task-level model_settings override config-level settings."""
-        _, settings, _, _, _ = _resolve_task_model(
+        _, settings, _, _, _ = resolve_task_model(
             TaskDefinition(model="fast", model_settings={"temperature": 0.2}),
             model_keys=["fast"],
             model_dict={"fast": "gpt-4o-mini"},
@@ -218,7 +218,7 @@ class TestResolveTaskModel:
 
     def test_engine_keys_extracted(self):
         """Engine keys (api_type, endpoint, token) are popped from settings."""
-        _, settings, api_type, endpoint, token = _resolve_task_model(
+        _, settings, api_type, endpoint, token = resolve_task_model(
             TaskDefinition(model="fast"),
             model_keys=["fast"],
             model_dict={"fast": "gpt-4o-mini"},
@@ -241,19 +241,19 @@ class TestResolveTaskModel:
 
     def test_default_model_when_empty(self):
         """Empty model string falls back to DEFAULT_MODEL."""
-        from seclab_taskflow_agent.agent import DEFAULT_MODEL
+        from seclab_taskflow_agent.capi import get_default_model
 
-        model_id, _, _, _, _ = _resolve_task_model(
+        model_id, _, _, _, _ = resolve_task_model(
             TaskDefinition(model=""),
             model_keys=[],
             model_dict={},
             models_params={},
         )
-        assert model_id == DEFAULT_MODEL
+        assert model_id == get_default_model()
 
     def test_model_not_in_keys_passes_through(self):
         """A model name not in model_keys passes through as-is."""
-        model_id, _, _, _, _ = _resolve_task_model(
+        model_id, _, _, _, _ = resolve_task_model(
             TaskDefinition(model="claude-3-opus"),
             model_keys=["fast", "smart"],
             model_dict={"fast": "gpt-4o-mini", "smart": "gpt-4o"},
@@ -263,7 +263,7 @@ class TestResolveTaskModel:
 
     def test_task_engine_keys_override_config(self):
         """Task-level model_settings can override engine keys from config."""
-        _, _, api_type, endpoint, token = _resolve_task_model(
+        _, _, api_type, endpoint, token = resolve_task_model(
             TaskDefinition(
                 model="fast",
                 model_settings={"api_type": "responses", "endpoint": "https://task.api"},
@@ -297,7 +297,7 @@ class TestBuildPromptsToRun:
     def test_non_repeat_returns_single_prompt(self):
         """Without repeat_prompt, the original prompt is returned as-is."""
         result = self._run(
-            _build_prompts_to_run(
+            build_prompts_to_run(
                 task_prompt="hello world",
                 repeat_prompt=False,
                 last_mcp_tool_results=[],
@@ -313,7 +313,7 @@ class TestBuildPromptsToRun:
         items = [{"name": "apple"}, {"name": "banana"}]
         results = [self._result_entry(items)]
         prompts = self._run(
-            _build_prompts_to_run(
+            build_prompts_to_run(
                 task_prompt="Process {{ result.name }}",
                 repeat_prompt=True,
                 last_mcp_tool_results=results,
@@ -331,7 +331,7 @@ class TestBuildPromptsToRun:
         data = {"a": 1, "b": 2}
         results = [self._result_entry(data)]
         prompts = self._run(
-            _build_prompts_to_run(
+            build_prompts_to_run(
                 task_prompt="Key: {{ result }}",
                 repeat_prompt=True,
                 last_mcp_tool_results=results,
@@ -346,7 +346,7 @@ class TestBuildPromptsToRun:
         """repeat_prompt with an empty list renders no prompts."""
         results = [self._result_entry([])]
         prompts = self._run(
-            _build_prompts_to_run(
+            build_prompts_to_run(
                 task_prompt="Process {{ result }}",
                 repeat_prompt=True,
                 last_mcp_tool_results=results,
@@ -361,7 +361,7 @@ class TestBuildPromptsToRun:
         """IndexError when last_mcp_tool_results is empty."""
         with pytest.raises(IndexError):
             self._run(
-                _build_prompts_to_run(
+                build_prompts_to_run(
                     task_prompt="Process {{ result }}",
                     repeat_prompt=True,
                     last_mcp_tool_results=[],
@@ -376,7 +376,7 @@ class TestBuildPromptsToRun:
         results = [json.dumps({"text": "not json!!"})]
         with pytest.raises(ValueError, match="not valid JSON"):
             self._run(
-                _build_prompts_to_run(
+                build_prompts_to_run(
                     task_prompt="Process {{ result }}",
                     repeat_prompt=True,
                     last_mcp_tool_results=results,
@@ -393,7 +393,7 @@ class TestBuildPromptsToRun:
         original_len = len(results)
 
         self._run(
-            _build_prompts_to_run(
+            build_prompts_to_run(
                 task_prompt="Process {{ result.name }}",
                 repeat_prompt=True,
                 last_mcp_tool_results=results,
@@ -415,7 +415,7 @@ class TestBuildPromptsToRun:
             side_effect=Exception("template boom"),
         ), pytest.raises(Exception, match="template boom"):
             self._run(
-                _build_prompts_to_run(
+                build_prompts_to_run(
                     task_prompt="Process {{ result.name }}",
                     repeat_prompt=True,
                     last_mcp_tool_results=results,
@@ -432,7 +432,7 @@ class TestBuildPromptsToRun:
         results = [self._result_entry(42)]
         with pytest.raises(TypeError):
             self._run(
-                _build_prompts_to_run(
+                build_prompts_to_run(
                     task_prompt="Process {{ result }}",
                     repeat_prompt=True,
                     last_mcp_tool_results=results,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -291,7 +291,7 @@ class TestBuildPromptsToRun:
     @staticmethod
     def _run(coro):
         """Run an async coroutine with render_model_output mocked out."""
-        with patch("seclab_taskflow_agent.runner.render_model_output", new_callable=AsyncMock):
+        with patch("seclab_taskflow_agent.prompt_builder.render_model_output", new_callable=AsyncMock):
             return asyncio.run(coro)
 
     def test_non_repeat_returns_single_prompt(self):
@@ -411,7 +411,7 @@ class TestBuildPromptsToRun:
         results = [self._result_entry(items)]
 
         with patch(
-            "seclab_taskflow_agent.runner.render_template",
+            "seclab_taskflow_agent.prompt_builder.render_template",
             side_effect=Exception("template boom"),
         ), pytest.raises(Exception, match="template boom"):
             self._run(


### PR DESCRIPTION
Hi team, 

Following up on my issue #231, I had some free time and ended up coding a full Proof of Concept (POC) for the 4 architectural improvements we discussed. 

**⚠️ Important:** I am opening this as a **Draft** and I **do not expect you to merge this massive PR**. My goal is simply to show you the code so we have a concrete basis for discussion. 

### What this POC does:
1. **`agent.py` / `capi.py`**: Decoupled the LLM provider initialization (Dependency Injection) to easily support local models.
2. **`runner.py` cleanup**: Extracted ~210 lines into dedicated `prompt_builder.py` and `model_resolver.py` modules (Single Responsibility Principle).
3. **`mcp_lifecycle.py`**: Introduced a Registry pattern for MCP transports.

If you like the direction of this architecture, **I will close this Draft and open small, atomic PRs** (e.g., just the LLM decoupling first) to make reviewing easy for you. 

Let me know if this modular approach aligns with the team's vision!