### PR TITLE
Inherit proxy env vars in MCP server subprocesses

### DIFF
--- a/src/seclab_taskflow_agent/mcp_utils.py
+++ b/src/seclab_taskflow_agent/mcp_utils.py
@@ -175,6 +175,12 @@ def mcp_client_params(
                             logging.critical(e)
                             logging.info("Assuming toolbox has default configuration available")
                             del env[k]
+                    # Inherit proxy env vars from parent so HTTP clients
+                    # work correctly inside network-isolated environments (AWF)
+                    for proxy_var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+                                      "http_proxy", "https_proxy", "no_proxy"):
+                        if proxy_var not in env and proxy_var in os.environ:
+                            env[proxy_var] = os.environ[proxy_var]
                 logging.debug(f"Tool call environment: {env}")
                 if args:
                     for i, v in enumerate(args):

--- a/src/seclab_taskflow_agent/mcp_utils.py
+++ b/src/seclab_taskflow_agent/mcp_utils.py
@@ -20,6 +20,7 @@ __all__ = [
 import hashlib
 import json
 import logging
+import os
 import shutil
 from typing import Any
 


### PR DESCRIPTION
When toolbox YAML specifies an explicit `env` block, the subprocess gets only those vars (plus HOME/PATH from the MCP SDK defaults). `HTTP_PROXY`/`HTTPS_PROXY` from the parent are lost.

This breaks HTTPS inside network-isolated environments like AWF, where all traffic must route through a Squid proxy. The MCP file viewer and other servers fail with `[SSL] record layer failure` because Python tries direct connections that hit iptables DNAT instead of using the proxy.

Fix: inherit proxy-related env vars from the parent process into MCP server subprocess environments when they're not already set by the toolbox config.