### PR TITLE
fix: Yield to give mcp_session_task a chance to finish

### DIFF
--- a/src/seclab_taskflow_agent/runner.py
+++ b/src/seclab_taskflow_agent/runner.py
@@ -462,6 +462,9 @@ async def deploy_task_agents(
                 continue
             except Exception:
                 logging.exception("Exception in mcp server cleanup task")
+        # Yield to give mcp_session_task a chance to finish after being
+        # signalled, especially when there are no servers to clean up.
+        await asyncio.sleep(0)
         # If the MCP session task is still running (e.g. all servers were
         # already disconnected and the cleanup loop above never entered)
         # cancel it explicitly so a dangling task can't keep the event


### PR DESCRIPTION
Should prevent errors such as:

```
ERROR: Timeout on main session task
Traceback (most recent call last):
  File "/workspaces/seclab-taskflow-agent/src/seclab_taskflow_agent/mcp_lifecycle.py", line 147, in mcp_session_task
    await cleanup.wait()
  File "/usr/local/python/current/lib/python3.11/asyncio/locks.py", line 213, in wait
    await fut
asyncio.exceptions.CancelledError
```

when running a taskflow without toolboxes (MCP servers)