### PR TITLE
Split workflow to reduce the available permissions during the build step

### DIFF
--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -6,6 +6,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    outputs:
+      release_name: ${{ steps.create_version_number.outputs.RELEASE_NAME }}
 
     env:
       GITHUB_REPO: ${{ github.repository }}
@@ -90,5 +92,5 @@ jobs:
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_NAME: ${{ steps.create_version_number.outputs.RELEASE_NAME }}
+        RELEASE_NAME: ${{ needs.build.outputs.release_name }}
       run: gh release create $RELEASE_NAME dist/* --repo $GITHUB_REPO --prerelease --generate-notes

--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -3,22 +3,15 @@ name: Publish Pre-Release to TestPyPI
 on: workflow_dispatch
 
 jobs:
-  publish:
-    name: Build
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
-
-    # This environment is required as an input to pypa/gh-action-pypi-publish
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/seclab-taskflow-agent
 
     env:
       GITHUB_REPO: ${{ github.repository }}
 
     permissions:
-      contents: write
-      id-token: write  # For trusted publishing
-      attestations: write  # For artifact attestation
+      contents: read
 
     steps:
     - name: Checkout repository
@@ -29,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Install Hatch
       run: pip install --upgrade hatch
@@ -52,16 +45,41 @@ jobs:
     - name: Build the wheel
       run: python3 -m hatch build
 
-    - name: Attest build provenance
-      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
-      with:
-        subject-path: ./dist/*
-
     - name: Upload artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
         name: python-package-distributions
         path: ./dist/
+
+  publish:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    # This environment is required as an input to pypa/gh-action-pypi-publish
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/seclab-taskflow-agent
+
+    env:
+      GITHUB_REPO: ${{ github.repository }}
+
+    permissions:
+      contents: write
+      id-token: write  # For trusted publishing
+      attestations: write  # For artifact attestation
+
+    steps:
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: python-package-distributions
+        path: ./dist/
+
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+      with:
+        subject-path: ./dist/*
 
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0


### PR DESCRIPTION
Fixes: #228 (but testing it on the TestPyPI workflow first)

I don't like what @copilot did in #230. It randomly downgraded some of the actions that're used and it also deleted the attestation step. So I'm doing it manually, so that I have higher confidence that the steps were only moved, not changed.

One change that I've made here that I'm unsure about is that the order of uploading artifacts and provenance attestation is swapped. I need to do that so that the attestation is done in the second job. Hopefully it'll still work.