### PR TITLE
replace attest-build-provenance with attest

### DIFF
--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -79,7 +79,7 @@ jobs:
         path: ./dist/
 
     - name: Attest build provenance
-      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+      uses: actions/attest@v4.1.0 # immutable release
       with:
         subject-path: ./dist/*
 


### PR DESCRIPTION
Apparently, attest-build-provenance is now just a simple wrapper around attest: https://github.com/actions/attest-build-provenance#usage