### PR TITLE
Pin actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,16 +29,16 @@ jobs:
             build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@v4.36.0 # immutable release
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@v4.36.0 # immutable release
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.14"
 
@@ -32,7 +32,7 @@ jobs:
       run: python3 -m hatch build
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: python-package-distributions
         path: ./dist/
@@ -68,7 +68,7 @@ jobs:
         subject-path: ./dist/*
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         verbose: true
 

--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.14"
 
@@ -48,7 +48,7 @@ jobs:
       run: python3 -m hatch build
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: python-package-distributions
         path: ./dist/
@@ -84,7 +84,7 @@ jobs:
         subject-path: ./dist/*
 
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/
         verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
@@ -40,7 +40,7 @@ jobs:
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4.1.0 # immutable release
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.USER }}/${{ env.IMAGE_NAME }}
           subject-digest: '${{ steps.docker_build.outputs.digest }}'

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -5,7 +5,7 @@ on:
     types: [created] # Add "smoke test" as a PR comment to trigger this workflow.
 
 # Permissions needed for reacting and adding comments for IssueOps commands
-# See: https://github.com/github/branch-deploy/blob/48285b12b35e47e2dde0c27d2abb33daa846d98b/README.md?plain=1#L189-L197
+# See: https://github.com/github/branch-deploy/blob/ddf8ca48e9cdb2d2c7c71dee428308b19af9313f/README.md?plain=1#L189-L197
 permissions:
   pull-requests: write # Required for commenting on PRs
   deployments: write # Required for updating deployment statuses

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Branch Deploy
         id: branch-deploy
-        uses: github/branch-deploy@48285b12b35e47e2dde0c27d2abb33daa846d98b # v11.0.0
+        uses: github/branch-deploy@ddf8ca48e9cdb2d2c7c71dee428308b19af9313f # v11.1.4
         with:
           trigger: "smoke test"
           reaction: "eyes"
@@ -31,13 +31,13 @@ jobs:
 
       - name: Setup Python
         if: steps.branch-deploy.outputs.continue == 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
       - name: Checkout the repo
         if: steps.branch-deploy.outputs.continue == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.branch-deploy.outputs.sha }}
 


### PR DESCRIPTION
I checked all of these manually. If the action uses immutable releases, then I use the version number:

```
uses: actions/attest@v4.1.0 # immutable release
```

otherwise, I use the SHA:

```
actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
```