### PR TITLE
Resolve env templates in remote MCP server urls

### DIFF
--- a/src/seclab_taskflow_agent/mcp_utils.py
+++ b/src/seclab_taskflow_agent/mcp_utils.py
@@ -238,13 +238,13 @@ def mcp_client_params(
 
             case "sse":
                 headers = _resolve_headers(sp.headers, sp.optional_headers)
-                server_params["url"] = sp.url
+                server_params["url"] = swap_env(sp.url) if sp.url is not None else None
                 server_params["headers"] = headers
                 server_params["timeout"] = sp.timeout
 
             case "streamable":
                 headers = _resolve_headers(sp.headers, sp.optional_headers)
-                server_params["url"] = sp.url
+                server_params["url"] = swap_env(sp.url) if sp.url is not None else None
                 server_params["headers"] = headers
                 server_params["timeout"] = sp.timeout
 

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -196,3 +196,34 @@ def test_env_names_returns_sorted_names_or_none():
     assert _env_names({"B_VAR": "x", "A_VAR": "{{ env('A') }}"}) == ["A_VAR", "B_VAR"]
     assert _env_names({}) == []
     assert _env_names(None) is None
+
+
+@pytest.mark.parametrize("kind", ["streamable", "sse"])
+def test_mcp_client_params_resolves_remote_url_env(monkeypatch, kind):
+    # A remote toolbox sources its endpoint from the environment. The url must
+    # be env-templated the same way stdio args/env and headers already are, so
+    # `url: "{{ env('CONTAINER_SHELL_URL') }}"` reaches the client resolved.
+    monkeypatch.setenv("CONTAINER_SHELL_URL", "http://host.docker.internal:8765/mcp/")
+    server_params = SimpleNamespace(
+        kind=kind,
+        reconnecting=False,
+        url="{{ env('CONTAINER_SHELL_URL') }}",
+        headers=None,
+        optional_headers=None,
+        timeout=None,
+        command=None,
+        env=None,
+        args=None,
+    )
+    toolbox = SimpleNamespace(
+        server_params=server_params,
+        confirm=["container_shell_exec"],
+        server_prompt=None,
+        client_session_timeout=None,
+    )
+    available_tools = MagicMock()
+    available_tools.get_toolbox.return_value = toolbox
+
+    params = mcp_client_params(available_tools, ["pkg.remote"])
+
+    assert params["pkg.remote"][0]["url"] == "http://host.docker.internal:8765/mcp/"


### PR DESCRIPTION
Apply `swap_env` to the `url` of `sse` and `streamable` toolboxes so a remote MCP endpoint can be sourced from the environment.

## Why

Stdio toolboxes already env-template their `args` and `env`, and both remote transports env-template their `headers`, but the `url` was passed to the client verbatim. That meant a toolbox could not do:

```yaml
server_params:
  kind: streamable
  url: "{{ env('CONTAINER_SHELL_URL') }}"
```

The literal `{{ env(...) }}` string reached `MCPServerStreamableHttp` and the connection failed. This blocks remote toolboxes whose endpoint is only known at runtime, such as a `container_shell` server reached over an allowlisted host service port.

## What

`mcp_client_params` now runs `swap_env(sp.url)` for both the `sse` and `streamable` branches (guarded for `None`). Behavior is unchanged for urls without a template.

## Tests

Added a parametrized test (`streamable` and `sse`) asserting that `url: "{{ env('CONTAINER_SHELL_URL') }}"` resolves to the concrete endpoint through `mcp_client_params`. Full suite: 547 passed, 2 skipped.