### PR TITLE
Prefix compressed MCP namespaces so tool names start with a letter

### DIFF
--- a/src/seclab_taskflow_agent/mcp_utils.py
+++ b/src/seclab_taskflow_agent/mcp_utils.py
@@ -44,6 +44,16 @@ DEFAULT_MCP_CLIENT_SESSION_TIMEOUT: int = 120
 # We hash long names down to this many hex characters.
 COMPRESSED_NAME_LENGTH: int = 12
 
+# Gemini requires a function name to begin with a letter or an underscore, and
+# a hex digest begins with a digit ten times in sixteen. Left bare, a namespace
+# yields tool names such as ``8fb2adfa03efcontainer_shell_exec``, which Gemini
+# refuses with 400 ``invalid_request_body`` for the whole request, so one
+# unlucky digest takes down every tool in the run and not just that server's.
+# OpenAI and Anthropic document the laxer ``^[a-zA-Z0-9_-]{1,64}$`` and do
+# accept a leading digit, which is why this presents as a model-specific fault.
+# https://ai.google.dev/api/caching#FunctionDeclaration
+COMPRESSED_NAME_PREFIX: str = "ns"
+
 
 def compress_name(name: str) -> str:
     """Return a short hash of *name* to fit the OpenAI 64-char tool-name limit.
@@ -52,11 +62,12 @@ def compress_name(name: str) -> str:
         name: The original tool / toolbox name.
 
     Returns:
-        A 12-character lowercase hex digest.
+        A lowercase hex digest of ``COMPRESSED_NAME_LENGTH`` characters, behind
+        a fixed prefix so the result always starts with a letter.
     """
     m = hashlib.sha256()
     m.update(name.encode("utf-8"))
-    return m.hexdigest()[:COMPRESSED_NAME_LENGTH]
+    return COMPRESSED_NAME_PREFIX + m.hexdigest()[:COMPRESSED_NAME_LENGTH]
 
 
 class MCPNamespaceWrap:

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -134,6 +134,36 @@ def test_list_tools_unfiltered_idempotent_on_prefixed_input():
     assert not result[0].name.startswith(f"{ns}{ns}")
 
 
+# -- compress_name() --
+
+
+@pytest.mark.parametrize(
+    "server_name",
+    # "ContainerShell" is one whose sha256 starts with a digit, which is what
+    # made this show up as an intermittent failure of unrelated toolboxes.
+    ["ContainerShell", "RepoContext", "FindingLedger", "RepoSurvey", "", "x" * 200],
+)
+def test_compress_name_starts_with_a_letter(server_name):
+    """Gemini rejects a function name that starts with a digit.
+
+    A namespace is prefixed to every tool a server exposes, so a digest
+    beginning with a digit produces names like `8fb2adfa03efcontainer_shell_exec`.
+    Gemini answers 400 `invalid_request_body` to the whole request, taking down
+    every tool in the run and not just the offending server's.
+    """
+    assert compress_name(server_name)[0].isalpha()
+
+
+def test_compress_name_is_stable_and_distinct():
+    assert compress_name("RepoContext") == compress_name("RepoContext")
+    assert compress_name("RepoContext") != compress_name("RepoSurvey")
+
+
+def test_compress_name_leaves_room_under_the_64_character_limit():
+    """The prefix must not eat the headroom the compression exists to create."""
+    assert len(compress_name("x" * 200)) + len("a_very_long_tool_name_indeed") <= 64
+
+
 # -- list_tools() (regression) --
 
 


### PR DESCRIPTION
## The bug

`compress_name` returns a bare sha256 prefix, and that value is prepended to the name of every tool an MCP server exposes:

```python
tool_copy.name = f"{self.namespace}{tool.name}"
```

A hex digest starts with a digit ten times in sixteen, so a server whose name hashes unluckily produces tool names like `8fb2adfa03efcontainer_shell_exec`.

Gemini documents that a function name ["must start with a letter or an underscore"](https://ai.google.dev/api/caching#FunctionDeclaration), and enforces it by rejecting the **entire request**. So one unlucky server name disables every tool in the run, not just that server's.

Probed against CAPI, sending the same minimal request twice and changing only the tool name:

| model | endpoint | `8fb2adfa03ef…` | `ns8fb2adfa03ef…` |
|---|---|---|---|
| `gemini-3.6-flash` | chat completions | 400 `invalid_request_body` | ok |
| `claude-sonnet-5` | chat completions | ok | ok |
| `gpt-5-mini` | chat completions | ok | ok |
| `gpt-5.4` | chat completions | ok | ok |
| `gpt-5.6-sol` | responses | ok | ok |
| `grok-4.5` | responses | ok | ok |

Only Gemini rejects it. OpenAI and Anthropic document the laxer `^[a-zA-Z0-9_-]{1,64}$`, which permits a leading digit, and they do accept it in practice.

That narrowness is what makes this expensive to diagnose. The same taskflow works on most models and fails on one; the error names no tool and no server; and whether you hit it at all depends on the sha256 of a server name nobody chose for its hash. I found it on a multi-model task where the Gemini branch was the only one that died, and the obvious readings — entitlements, a malformed tool schema, the wrong endpoint — were all wrong.

## The fix

Prefix the digest with a fixed `ns` so the result always starts with a letter. The namespace is opaque and is stripped with `removeprefix`, so nothing else changes; the name grows from 12 characters to 14, well inside the 64-character limit the compression exists to respect. `compress_name` is also used for handoff agent names in `runner.py`, which get the same treatment.

Conforming to the strictest of the three documented patterns costs two characters and removes a class of failure that is invisible until a specific server name meets a specific provider.

## Tests

Adds `compress_name` coverage for the leading character (including `ContainerShell`, one of the names that actually triggers this), stability, distinctness, and the 64-character budget. Full suite passes: 556 passed, 2 skipped.
