### PR TITLE
chore: remove references to GitHub models

### DIFF
--- a/src/seclab_taskflow_agent/capi.py
+++ b/src/seclab_taskflow_agent/capi.py
@@ -3,7 +3,7 @@
 
 """AI API endpoint and token management.
 
-Supports multiple API providers (GitHub Copilot, GitHub Models, OpenAI, and
+Supports multiple API providers (GitHub Copilot, OpenAI, and
 custom endpoints).  All provider-specific behaviour is captured in a single
 ``APIProvider`` dataclass so that adding a new provider only requires one
 registry entry instead of changes scattered across multiple match/case blocks.
@@ -91,19 +91,6 @@ class _CopilotProvider(APIProvider):
         )
 
 
-class _GitHubModelsProvider(APIProvider):
-    """GitHub Models API (models.github.ai)."""
-
-    def parse_models_list(self, body: Any) -> list[dict]:
-        # Models API returns a bare list, not {"data": [...]}
-        if isinstance(body, list):
-            return body
-        return super().parse_models_list(body)
-
-    def check_tool_calls(self, _model: str, model_info: dict) -> bool:
-        return "tool-calling" in model_info.get("capabilities", [])
-
-
 class _OpenAIProvider(APIProvider):
     """OpenAI API (api.openai.com).
 
@@ -126,12 +113,6 @@ _PROVIDERS: dict[str, APIProvider] = {
         base_url="https://api.githubcopilot.com",
         default_model="gpt-4.1",
         extra_headers={"Copilot-Integration-Id": COPILOT_INTEGRATION_ID},
-    ),
-    "models.github.ai": _GitHubModelsProvider(
-        name="github-models",
-        base_url="https://models.github.ai/inference",
-        models_catalog="/catalog/models",
-        default_model="openai/gpt-4.1",
     ),
     "api.openai.com": _OpenAIProvider(
         name="openai",

--- a/tests/test_api_endpoint_config.py
+++ b/tests/test_api_endpoint_config.py
@@ -17,7 +17,7 @@ class TestAPIEndpoint:
     """Test API endpoint configuration."""
 
     def test_default_api_endpoint(self):
-        """Test that default API endpoint is set to models.github.ai/inference."""
+        """Test that the default API endpoint is GitHub Copilot."""
         try:
             original_env = os.environ.pop("AI_API_ENDPOINT", None)
             endpoint = get_AI_endpoint()
@@ -41,7 +41,6 @@ class TestAPIEndpoint:
 
     def test_provider_base_urls(self):
         """Test that providers resolve to expected base URLs."""
-        assert get_provider("https://models.github.ai/inference").base_url == "https://models.github.ai/inference/"
         assert get_provider("https://api.githubcopilot.com").base_url == "https://api.githubcopilot.com/"
         assert get_provider("https://api.openai.com/v1").base_url == "https://api.openai.com/v1/"
 

--- a/tests/test_capi_extended.py
+++ b/tests/test_capi_extended.py
@@ -45,28 +45,6 @@ class TestSupportsToolCalls:
         }
         assert supports_tool_calls("text-only", models) is False
 
-    def test_models_github_endpoint(self, monkeypatch):
-        """models.github.ai checks for 'tool-calling' in capabilities list."""
-        monkeypatch.setenv("AI_API_ENDPOINT", "https://models.github.ai/inference")
-        models = {
-            "openai/gpt-4o": {
-                "id": "openai/gpt-4o",
-                "capabilities": ["tool-calling", "chat"],
-            }
-        }
-        assert supports_tool_calls("openai/gpt-4o", models) is True
-
-    def test_models_github_endpoint_no_tool_calling(self, monkeypatch):
-        """models.github.ai returns False when 'tool-calling' not in list."""
-        monkeypatch.setenv("AI_API_ENDPOINT", "https://models.github.ai/inference")
-        models = {
-            "some-model": {
-                "id": "some-model",
-                "capabilities": ["chat"],
-            }
-        }
-        assert supports_tool_calls("some-model", models) is False
-
     def test_openai_endpoint_model_in_catalog(self, monkeypatch):
         """OpenAI endpoint returns True for known chat model families."""
         monkeypatch.setenv("AI_API_ENDPOINT", "https://api.openai.com/v1")
@@ -117,12 +95,6 @@ class TestGetProvider:
         assert p.name == "copilot"
         assert p.base_url == "https://api.githubcopilot.com/"
         assert "Copilot-Integration-Id" in p.extra_headers
-
-    def test_github_models_provider(self):
-        p = get_provider("https://models.github.ai/inference")
-        assert p.name == "github-models"
-        assert p.models_catalog == "/catalog/models"
-        assert p.default_model == "openai/gpt-4.1"
 
     def test_openai_provider(self):
         p = get_provider("https://api.openai.com/v1")

--- a/tests/test_sdk_anthropic_adapter.py
+++ b/tests/test_sdk_anthropic_adapter.py
@@ -222,13 +222,10 @@ def test_call_tool_result_to_text_preserves_empty_among_nonempty():
 
 
 def test_known_provider_uses_bearer_auth():
-    """Known providers (CAPI, GitHub Models) should have bearer_auth=True."""
+    """Known CAPI providers should have bearer_auth=True."""
     from seclab_taskflow_agent.capi import get_provider
 
     provider = get_provider("https://api.githubcopilot.com")
-    assert provider.bearer_auth is True
-
-    provider = get_provider("https://models.github.ai/inference")
     assert provider.bearer_auth is True
 
 

--- a/tests/test_sdk_anthropic_adapter.py
+++ b/tests/test_sdk_anthropic_adapter.py
@@ -222,7 +222,7 @@ def test_call_tool_result_to_text_preserves_empty_among_nonempty():
 
 
 def test_known_provider_uses_bearer_auth():
-    """Known CAPI providers should have bearer_auth=True."""
+    """Known providers like CAPI should have bearer_auth=True."""
     from seclab_taskflow_agent.capi import get_provider
 
     provider = get_provider("https://api.githubcopilot.com")


### PR DESCRIPTION
GitHub Models were retired on July 30, 2026
https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/